### PR TITLE
fix: resolve NameError for final_kelly (#22) and update grok-beta model name (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python cli.py dashboard
 ## ✅ Features
 
 ### Multi-Model AI Ensemble
-- ✅ **Five frontier LLMs** collaborate on every decision — Grok-beta, Claude 3.5 Sonnet, GPT-4o, Gemini Flash 1.5, DeepSeek R1
+- ✅ **Five frontier LLMs** collaborate on every decision — Grok-3, Claude 3.5 Sonnet, GPT-4o, Gemini Flash 1.5, DeepSeek R1
 - ✅ **Role-based specialization** — each model plays a distinct analytical role (forecaster, bull, bear, risk manager, news analyst)
 - ✅ **Consensus gating** — positions are skipped when models diverge beyond a configurable confidence threshold
 - ✅ **Deterministic outputs** — temperature=0 for reproducible AI reasoning
@@ -125,7 +125,7 @@ Each of the five models analyzes the incoming data from its assigned perspective
 
 | Model | Role | Weight |
 |---|---|---|
-| Grok-beta (xAI) | Lead Forecaster | 30% |
+| Grok-3 (xAI) | Lead Forecaster | 30% |
 | Claude 3.5 Sonnet (OpenRouter) | News Analyst | 20% |
 | GPT-4o (OpenRouter) | Bull Researcher | 20% |
 | Gemini Flash 1.5 (OpenRouter) | Bear Researcher | 15% |
@@ -314,6 +314,8 @@ daily_ai_cost_limit    = 50.0    # Max daily AI API spend (USD)
 ```
 
 The ensemble configuration (model roster, weights, debate settings) lives in `EnsembleConfig` in the same file.
+
+> **⚠️ AI Model Names** — xAI periodically renames Grok models. The default is currently set to `grok-3`. If you see a `model not found` error, update `primary_model` in `TradingConfig` and the `"grok-3"` key in `EnsembleConfig.models` to match the latest model name from [console.x.ai](https://console.x.ai/). You can also override via environment variable: set `PRIMARY_MODEL=grok-3-mini` (or any valid model ID) in your `.env` file.
 
 ---
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -30,7 +30,7 @@ class EnsembleConfig:
     enabled: bool = True
     # Model roster for ensemble decisions
     models: Dict[str, Dict] = field(default_factory=lambda: {
-        "grok-beta": {"provider": "xai", "role": "forecaster", "weight": 0.30},
+        "grok-3": {"provider": "xai", "role": "forecaster", "weight": 0.30},
         "anthropic/claude-3.5-sonnet": {"provider": "openrouter", "role": "news_analyst", "weight": 0.20},
         "openai/gpt-4o": {"provider": "openrouter", "role": "bull_researcher", "weight": 0.20},
         "google/gemini-flash-1.5": {"provider": "openrouter", "role": "bear_researcher", "weight": 0.15},
@@ -94,7 +94,7 @@ class TradingConfig:
     scan_interval_seconds: int = 60      # SANE: 60-second scan interval (was 30)
     
     # AI model configuration
-    primary_model: str = "grok-beta"  # xAI Grok model for forecasting
+    primary_model: str = "grok-3"  # xAI Grok model for forecasting
     fallback_model: str = "grok-4-1-fast-non-reasoning"  # Fallback to fast non-reasoning variant
     ai_temperature: float = 0  # Lower temperature for more consistent JSON output
     ai_max_tokens: int = 8000    # Reasonable limit for reasoning models (grok-4 works better with 8000)

--- a/src/strategies/portfolio_optimization.py
+++ b/src/strategies/portfolio_optimization.py
@@ -172,7 +172,7 @@ class AdvancedPortfolioOptimizer:
                 # Update the opportunity object in place
                 opp.kelly_fraction = kelly_val
                 opp.fractional_kelly = kelly_val * 0.5  # Conservative Kelly
-                opp.risk_adjusted_fraction = final_kelly
+                opp.risk_adjusted_fraction = opp.fractional_kelly
             
             # Step 4: Apply correlation adjustments
             correlation_matrix = await self._estimate_correlation_matrix(enhanced_opportunities)


### PR DESCRIPTION
## Summary

Two bug fixes reported by community users:

### Fix #22 — `final_kelly` NameError in portfolio_optimization.py

**Root cause:** In `optimize_portfolio()`, the loop at line 175 referenced `final_kelly`, a variable only defined inside `_calculate_kelly_fractions()`. This caused a `NameError` at runtime.

**Fix:** Changed `opp.risk_adjusted_fraction = final_kelly` to `opp.risk_adjusted_fraction = opp.fractional_kelly`, which is the conservative Kelly value (kelly_val × 0.5) calculated on the preceding line — the correct intended behavior.

### Fix #20 — Deprecated `grok-beta` model name

**Root cause:** xAI renamed their model from `grok-beta` to `grok-3`. Using the old name causes a `model not found` error.

**Fix:** Updated `primary_model` in `TradingConfig` and the model key in `EnsembleConfig.models` from `grok-beta` to `grok-3`. Also updated README to reflect current model name and added a note about overriding via environment variables.

## Files Changed
- `src/strategies/portfolio_optimization.py` — NameError fix
- `src/config/settings.py` — model name update
- `README.md` — docs update + model name override instructions

## Testing
- Python `ast.parse()` syntax check passes on both modified files.

Closes #22
Addresses #20