### PR TITLE
fix: persist xAI costs to DB for dashboard visibility (#24)

### DIFF
--- a/src/clients/xai_client.py
+++ b/src/clients/xai_client.py
@@ -146,6 +146,21 @@ class XAIClient(TradingLoggerMixin):
                 requests_today=self.daily_tracker.request_count
             )
 
+    async def _persist_cost_to_db(self, cost: float) -> None:
+        """
+        Persist an xAI API cost increment to the database so that the
+        dashboard / evaluate job can read accurate spending data.
+
+        This is a fire-and-forget async helper — errors are logged but not
+        raised so they never interrupt the trading flow.
+        """
+        if not self.db_manager or cost <= 0:
+            return
+        try:
+            await self.db_manager.upsert_daily_cost(cost)
+        except Exception as e:
+            self.logger.warning(f"Failed to persist xAI cost to DB: {e}")
+
     async def _check_daily_limits(self) -> bool:
         """
         Check if we should pause due to daily limits.
@@ -311,9 +326,15 @@ class XAIClient(TradingLoggerMixin):
                     )
                     return self._get_fallback_context(query, max_length)
                 
-                # Process successful response
+                # Process successful response (also calls _update_daily_cost internally)
                 search_result = self._process_search_response(response, query, processing_time, max_length)
-                
+
+                # Persist search cost to DB (fire-and-forget)
+                sources_used_count = getattr(response.usage, 'num_sources_used', 0) if hasattr(response, 'usage') else 0
+                search_cost_for_db = sources_used_count * 0.025
+                if search_cost_for_db > 0:
+                    asyncio.create_task(self._persist_cost_to_db(search_cost_for_db))
+
                 # Cache the result
                 cache_key = f"{optimized_query[:50]}:{max_length}"
                 if len(self._search_cache) < 100:  # Limit cache size
@@ -385,10 +406,10 @@ Provide a brief, factual summary under {max_length//2} words. If no current info
         # Calculate costs and usage
         sources_used = getattr(response.usage, 'num_sources_used', 0) if hasattr(response, 'usage') else 0
         search_cost = sources_used * 0.025  # $0.025 per source
-        
-        self.total_cost += search_cost
-        self.request_count += 1
-        
+
+        # Route through daily tracker so the limit is enforced and DB gets updated
+        self._update_daily_cost(search_cost)
+
         self.logger.info(
             "xAI search completed successfully",
             query=original_query[:50],
@@ -813,8 +834,9 @@ Required format:
                 self.total_cost += cost
                 self.request_count += 1
                 
-                # Update daily cost tracking
+                # Update daily cost tracking (pickle) and persist to DB
                 self._update_daily_cost(cost)
+                asyncio.create_task(self._persist_cost_to_db(cost))
                 
                 self.logger.debug(
                     "xAI completion request successful",
@@ -913,7 +935,10 @@ Required format:
                 
                 self.total_cost += cost
                 self.request_count += 1
-                
+
+                # Persist fallback model cost to DB as well
+                asyncio.create_task(self._persist_cost_to_db(cost))
+
                 self.logger.info(
                     f"✅ Fallback model {fallback_model} succeeded",
                     response_length=len(response_content),

--- a/src/jobs/evaluate.py
+++ b/src/jobs/evaluate.py
@@ -4,12 +4,41 @@ Enhanced evaluation system with cost monitoring and trading performance analysis
 
 import asyncio
 import aiosqlite
+import os
+import pickle
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
 from src.utils.database import DatabaseManager
 from src.config.settings import settings
 from src.utils.logging_setup import get_trading_logger
+
+
+def _read_xai_tracker_from_pickle() -> Optional[dict]:
+    """
+    Read the in-memory DailyUsageTracker that xai_client persists to disk.
+
+    Returns a plain dict with keys: date, total_cost, request_count,
+    daily_limit, is_exhausted — or None if the file is missing/unreadable.
+    """
+    usage_file = "logs/daily_ai_usage.pkl"
+    try:
+        if os.path.exists(usage_file):
+            with open(usage_file, "rb") as f:
+                tracker = pickle.load(f)
+            today = datetime.now().strftime("%Y-%m-%d")
+            if getattr(tracker, "date", None) == today:
+                return {
+                    "date": tracker.date,
+                    "total_cost": getattr(tracker, "total_cost", 0.0),
+                    "request_count": getattr(tracker, "request_count", 0),
+                    "daily_limit": getattr(tracker, "daily_limit", 50.0),
+                    "is_exhausted": getattr(tracker, "is_exhausted", False),
+                }
+    except Exception:
+        pass
+    return None
+
 
 async def analyze_ai_costs(db_manager: DatabaseManager) -> Dict:
     """Analyze AI spending patterns and provide cost optimization recommendations."""
@@ -62,30 +91,66 @@ async def analyze_ai_costs(db_manager: DatabaseManager) -> Dict:
         """, (week_ago,))
         analysis_breakdown = await cursor.fetchall()
     
-    # Calculate cost efficiency metrics
-    today_cost = daily_costs[today]['cost']
+    # ---------------------------------------------------------------------------
+    # Merge DB costs with in-memory xAI tracker (belt-and-suspenders).
+    # xAI clients now persist costs to DB via upsert_daily_cost(), but if the
+    # bot was last run on an older version the pickle may still hold more data.
+    # ---------------------------------------------------------------------------
+    xai_tracker = _read_xai_tracker_from_pickle()
+    xai_cost_today = xai_tracker["total_cost"] if xai_tracker else 0.0
+    xai_requests_today = xai_tracker["request_count"] if xai_tracker else 0
+    trading_paused = (xai_tracker["is_exhausted"] if xai_tracker else False)
+
+    # Use the higher of DB cost vs. pickle cost (DB is authoritative going
+    # forward; pickle is the fallback for backwards-compat).
+    db_today_cost = daily_costs[today]['cost']
+    today_cost = max(db_today_cost, xai_cost_today)
+
+    # Backfill the daily_costs dict so callers see the merged value
+    daily_costs[today]['cost'] = today_cost
+    daily_costs[today]['xai_requests'] = xai_requests_today
+
     today_decisions = daily_costs[today]['decisions']
     cost_per_decision = today_cost / max(1, today_decisions)
-    
+
     weekly_cost = weekly_stats[0] if weekly_stats and weekly_stats[0] else 0.0
     weekly_analyses = weekly_stats[1] if weekly_stats and weekly_stats[1] else 0
     weekly_decisions = weekly_stats[2] if weekly_stats and weekly_stats[2] else 0
-    
+
+    # Use the *actual* enforced limit (daily_ai_cost_limit) for all threshold
+    # calculations — not the softer daily_ai_budget display value.
+    actual_limit = getattr(settings.trading, 'daily_ai_cost_limit', 50.0)
+    soft_budget  = getattr(settings.trading, 'daily_ai_budget', 10.0)
+
     # Generate recommendations
     recommendations = []
-    
-    if today_cost > settings.trading.daily_ai_budget * 0.8:
-        recommendations.append(f"⚠️  Near daily budget limit: ${today_cost:.3f} / ${settings.trading.daily_ai_budget}")
-    
+
+    if trading_paused:
+        recommendations.append(
+            f"🚫 Trading PAUSED — daily xAI limit reached: "
+            f"${today_cost:.3f} / ${actual_limit:.2f} "
+            f"({xai_requests_today} requests)"
+        )
+
+    if today_cost > soft_budget * 0.8:
+        recommendations.append(
+            f"⚠️  Near soft budget threshold: ${today_cost:.3f} / ${soft_budget:.2f}"
+        )
+
+    if today_cost > actual_limit * 0.8:
+        recommendations.append(
+            f"🔴 Near hard xAI limit: ${today_cost:.3f} / ${actual_limit:.2f}"
+        )
+
     if cost_per_decision > settings.trading.max_ai_cost_per_decision:
         recommendations.append(f"💰 High cost per decision: ${cost_per_decision:.3f}")
-    
-    if weekly_cost > settings.trading.daily_ai_budget * 5:  # More than 5 days of budget in a week
+
+    if weekly_cost > soft_budget * 5:  # More than 5 days of soft budget in a week
         recommendations.append("📈 Weekly spending trending high - consider tighter controls")
-    
+
     if weekly_analyses > weekly_decisions * 3:  # Too many analyses relative to decisions
         recommendations.append("🔄 High analysis-to-decision ratio - improve filtering")
-    
+
     # Log comprehensive cost report
     logger.info(
         "AI Cost Analysis Report",
@@ -95,17 +160,23 @@ async def analyze_ai_costs(db_manager: DatabaseManager) -> Dict:
         cost_per_decision=cost_per_decision,
         weekly_analyses=weekly_analyses,
         weekly_decisions=weekly_decisions,
-        budget_utilization=today_cost / settings.trading.daily_ai_budget,
-        recommendations=recommendations
+        budget_utilization=today_cost / soft_budget if soft_budget else 0,
+        hard_limit_utilization=today_cost / actual_limit if actual_limit else 0,
+        trading_paused=trading_paused,
+        xai_requests_today=xai_requests_today,
+        recommendations=recommendations,
     )
-    
+
     return {
         'daily_costs': daily_costs,
         'weekly_cost': weekly_cost,
         'cost_per_decision': cost_per_decision,
         'expensive_markets': expensive_markets,
         'analysis_breakdown': analysis_breakdown,
-        'recommendations': recommendations
+        'recommendations': recommendations,
+        'trading_paused': trading_paused,
+        'xai_requests_today': xai_requests_today,
+        'actual_daily_limit': actual_limit,
     }
 
 async def analyze_trading_performance(db_manager: DatabaseManager) -> Dict:
@@ -195,10 +266,14 @@ async def run_evaluation():
         
         # Generate overall system health summary
         daily_cost = cost_analysis['daily_costs'][datetime.now().strftime('%Y-%m-%d')]['cost']
-        budget_utilization = daily_cost / settings.trading.daily_ai_budget
+        actual_limit = cost_analysis.get('actual_daily_limit', settings.trading.daily_ai_budget)
+        budget_utilization = daily_cost / actual_limit if actual_limit else 0
+        trading_paused = cost_analysis.get('trading_paused', False)
         
         health_status = "🟢 HEALTHY"
-        if budget_utilization > 0.9:
+        if trading_paused:
+            health_status = "🔴 PAUSED — DAILY LIMIT REACHED"
+        elif budget_utilization > 0.9:
             health_status = "🔴 OVER BUDGET"
         elif budget_utilization > 0.7:
             health_status = "🟡 HIGH USAGE"

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -877,6 +877,33 @@ class DatabaseManager(TradingLoggerMixin):
             row = await cursor.fetchone()
             return row[0] if row else 0.0
 
+    async def upsert_daily_cost(self, cost: float, date: str = None) -> None:
+        """
+        Increment the daily AI cost total in the database.
+
+        Called by xAI/OpenRouter clients after every API request so that the
+        dashboard and evaluate job always reflect real spending — not just the
+        in-memory pickle tracker.
+
+        Args:
+            cost: Cost in USD to add to today's total.
+            date:  Date string (YYYY-MM-DD). Defaults to today.
+        """
+        if date is None:
+            date = datetime.now().strftime('%Y-%m-%d')
+        try:
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute("""
+                    INSERT INTO daily_cost_tracking (date, total_ai_cost, analysis_count, decision_count)
+                    VALUES (?, ?, 1, 0)
+                    ON CONFLICT(date) DO UPDATE SET
+                        total_ai_cost = total_ai_cost + excluded.total_ai_cost,
+                        analysis_count = analysis_count + 1
+                """, (date, cost))
+                await db.commit()
+        except Exception as e:
+            self.logger.error(f"Failed to upsert daily cost: {e}")
+
     async def get_market_analysis_count_today(self, market_id: str) -> int:
         """Get number of times market was analyzed today."""
         today = datetime.now().strftime('%Y-%m-%d')


### PR DESCRIPTION
## Problem
The xAI client tracks API costs in-memory (pickle file) and correctly enforces the daily $50 limit, but the dashboard and evaluate job read from the database — which was always $0.00 because xAI costs were never persisted to DB.

Also, the dashboard displayed $10 as the budget when the actual enforced limit is $50.

## Fix
- **`DatabaseManager.upsert_daily_cost()`** — new atomic upsert that increments daily cost tracking in SQLite
- **`XAIClient._persist_cost_to_db()`** — fire-and-forget async helper called after every API request (completions, search, fallback)
- **`evaluate.py`** — merges DB costs with pickle tracker (backwards-compat), uses actual enforced limit for utilization %, shows PAUSED state when limit is reached

## Backwards Compatible
- If `db_manager` isn't provided to XAIClient, persistence is silently skipped
- Pickle tracker continues to work as before — DB is additive

Fixes #24