### PR TITLE
fix: daily AI limit not resetting properly

### DIFF
--- a/beast_mode_bot.py
+++ b/beast_mode_bot.py
@@ -236,15 +236,17 @@ class BeastModeBot:
         if not settings.trading.enable_daily_cost_limiting:
             return True
         
-        # Check daily tracker in xAI client
-        if hasattr(xai_client, 'daily_tracker') and xai_client.daily_tracker.is_exhausted:
-            self.logger.warning(
-                "🚫 Daily AI cost limit reached - trading paused",
-                daily_cost=xai_client.daily_tracker.total_cost,
-                daily_limit=xai_client.daily_tracker.daily_limit,
-                requests_today=xai_client.daily_tracker.request_count
-            )
-            return False
+        # Use the client's reset-aware check (handles new-day resets)
+        if hasattr(xai_client, '_check_daily_limits'):
+            can_proceed = await xai_client._check_daily_limits()
+            if not can_proceed:
+                self.logger.warning(
+                    "🚫 Daily AI cost limit reached - trading paused",
+                    daily_cost=xai_client.daily_tracker.total_cost,
+                    daily_limit=xai_client.daily_tracker.daily_limit,
+                    requests_today=xai_client.daily_tracker.request_count
+                )
+            return can_proceed
         
         return True
 
@@ -351,8 +353,26 @@ Beast Mode Features:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="Set the logging level (default: INFO)"
     )
+    parser.add_argument(
+        "--reset-limits",
+        action="store_true",
+        help="Reset daily AI cost limits and exit (clears exhausted state)"
+    )
     
     args = parser.parse_args()
+    
+    # Handle --reset-limits
+    if args.reset_limits:
+        import glob
+        pkl_files = glob.glob("logs/daily_*usage*.pkl")
+        if pkl_files:
+            for f in pkl_files:
+                os.remove(f)
+                print(f"✅ Deleted {f}")
+            print("🔄 Daily AI limits reset. Restart the bot to continue trading.")
+        else:
+            print("ℹ️  No daily limit files found — limits are already clean.")
+        return
     
     # Setup logging
     setup_logging(log_level=args.log_level)

--- a/src/clients/openrouter_client.py
+++ b/src/clients/openrouter_client.py
@@ -151,6 +151,7 @@ class OpenRouterClient(TradingLoggerMixin):
     def _load_daily_tracker(self) -> DailyUsageTracker:
         """Load or create a daily usage tracker from disk."""
         today = datetime.now().strftime("%Y-%m-%d")
+        daily_limit = getattr(settings.trading, "daily_ai_cost_limit", 50.0)
         os.makedirs("logs", exist_ok=True)
 
         try:
@@ -160,13 +161,19 @@ class OpenRouterClient(TradingLoggerMixin):
                 if tracker.date != today:
                     tracker = DailyUsageTracker(
                         date=today,
-                        daily_limit=tracker.daily_limit,
+                        daily_limit=daily_limit,
                     )
+                else:
+                    # Always sync daily_limit from settings (user may have changed it)
+                    if tracker.daily_limit != daily_limit:
+                        tracker.daily_limit = daily_limit
+                        # Un-exhaust if new limit is higher than current cost
+                        if tracker.is_exhausted and tracker.total_cost < daily_limit:
+                            tracker.is_exhausted = False
                 return tracker
         except Exception as exc:
             self.logger.warning(f"Failed to load daily tracker: {exc}")
 
-        daily_limit = getattr(settings.trading, "daily_ai_cost_limit", 50.0)
         return DailyUsageTracker(date=today, daily_limit=daily_limit)
 
     def _save_daily_tracker(self) -> None:

--- a/src/clients/xai_client.py
+++ b/src/clients/xai_client.py
@@ -95,6 +95,7 @@ class XAIClient(TradingLoggerMixin):
         """Load or create daily usage tracker."""
         today = datetime.now().strftime("%Y-%m-%d")
         usage_file = "logs/daily_ai_usage.pkl"
+        daily_limit = getattr(settings.trading, 'daily_ai_cost_limit', 50.0)
         
         # Ensure logs directory exists
         os.makedirs("logs", exist_ok=True)
@@ -108,14 +109,20 @@ class XAIClient(TradingLoggerMixin):
                 if tracker.date != today:
                     tracker = DailyUsageTracker(
                         date=today,
-                        daily_limit=tracker.daily_limit  # Keep same limit
+                        daily_limit=daily_limit
                     )
+                else:
+                    # Always sync daily_limit from settings (user may have changed it)
+                    if tracker.daily_limit != daily_limit:
+                        tracker.daily_limit = daily_limit
+                        # Un-exhaust if new limit is higher than current cost
+                        if tracker.is_exhausted and tracker.total_cost < daily_limit:
+                            tracker.is_exhausted = False
                 return tracker
         except Exception as e:
             self.logger.warning(f"Failed to load daily tracker: {e}")
         
         # Create new tracker
-        daily_limit = getattr(settings.trading, 'daily_ai_cost_limit', 50.0)
         return DailyUsageTracker(date=today, daily_limit=daily_limit)
 
     def _save_daily_tracker(self):


### PR DESCRIPTION
## Problem

Daily AI cost limit gets stuck in exhausted state, blocking trading even after:
- Restarting the bot
- Changing `daily_ai_cost_limit` in settings.py
- Starting a new day

Root cause: `beast_mode_bot._check_daily_ai_limits()` read `is_exhausted` directly from the tracker pickle without triggering the date-reset logic.

## Fix

**Three changes:**

1. **beast_mode_bot.py** — `_check_daily_ai_limits()` now calls `xai_client._check_daily_limits()` which properly handles new-day resets instead of reading the raw `is_exhausted` field.

2. **xai_client.py + openrouter_client.py** — `_load_daily_tracker()` now syncs `daily_limit` from settings on every load. If you raise the limit above your current cost, the exhausted state clears automatically.

3. **New CLI flag** — `python beast_mode_bot.py --reset-limits` to manually clear all daily limit pickle files.

## Quick Fix (for anyone hitting this now)

Delete the pickle files:
```bash
rm logs/daily_ai_usage.pkl logs/daily_openrouter_usage.pkl
```

Or use the new flag:
```bash
python beast_mode_bot.py --reset-limits
```

Fixes #27