### PR TITLE
fix: lower daily AI cost limit to $10 and guard search() calls (fixes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python cli.py dashboard
 - ✅ **Hard daily loss limit** — stops trading at 15% drawdown
 - ✅ **Max drawdown circuit breaker** — halts at 50% portfolio drawdown
 - ✅ **Sector concentration cap** — no more than 90% in any single category
-- ✅ **Daily AI cost budget** — stops spending when API costs hit $50/day
+- ✅ **Daily AI cost budget** — stops spending when API costs hit the configurable daily limit (default: $10/day)
 
 ### Dynamic Exit Strategies
 - ✅ Trailing take-profit at 20% gain
@@ -310,8 +310,19 @@ ai_max_tokens          = 8000
 
 # Risk management
 max_daily_loss_pct     = 15.0    # Hard daily loss limit
-daily_ai_cost_limit    = 50.0    # Max daily AI API spend (USD)
+daily_ai_cost_limit    = 10.0    # Max daily AI API spend (USD) — default $10/day
 ```
+
+> **💸 Controlling AI spend (important for `movement_prediction` / xAI costs)**
+>
+> The bot checks daily spend limits **before every xAI API call** — including `search()` and all market analysis calls. Once the limit is reached, all AI calls are skipped until the next calendar day.
+>
+> Key knobs:
+> - `DAILY_AI_COST_LIMIT` env var (or `daily_ai_cost_limit` in `TradingConfig`) — max USD per day. **Default: $10.** Raise it only when you're comfortable with the spend. Example: `export DAILY_AI_COST_LIMIT=25`
+> - `scan_interval_seconds` — how often the bot scans markets. Lower = more AI calls per hour. Default: 60 seconds.
+> - `max_analyses_per_market_per_day` — cap on AI analyses per individual market per day. Default: 4.
+>
+> The `movement_prediction` strategy runs AI analysis on **every scan cycle** for all candidate markets. If you have many active markets and a short scan interval, costs add up fast. Reduce `scan_interval_seconds` (e.g. `120`) or lower `max_analyses_per_market_per_day` (e.g. `2`) to cut frequency.
 
 The ensemble configuration (model roster, weights, debate settings) lives in `EnsembleConfig` in the same file.
 

--- a/src/clients/xai_client.py
+++ b/src/clients/xai_client.py
@@ -39,7 +39,7 @@ class DailyUsageTracker:
     date: str
     total_cost: float = 0.0
     request_count: int = 0
-    daily_limit: float = 50.0  # Default $50 daily limit
+    daily_limit: float = 10.0  # Default $10 daily limit (override via DAILY_AI_COST_LIMIT env var)
     is_exhausted: bool = False
     last_exhausted_time: Optional[datetime] = None
 
@@ -275,6 +275,16 @@ class XAIClient(TradingLoggerMixin):
         Implements intelligent query processing, caching, and fallbacks.
         """
         try:
+            # Check daily limits BEFORE making any API call
+            if not await self._check_daily_limits():
+                self.logger.info(
+                    "Daily AI cost limit reached — search skipped",
+                    query=query[:50],
+                    daily_cost=self.daily_tracker.total_cost,
+                    daily_limit=self.daily_tracker.daily_limit,
+                )
+                return self._get_fallback_context(query, max_length)
+
             # Process and optimize the search query
             optimized_query = self._optimize_search_query(query)
             

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -140,7 +140,10 @@ class TradingConfig:
     max_analyses_per_market_per_day: int = 4  # INCREASED: More analyses per day (was 2, now 4)
     
     # Daily AI spending limits - SAFETY CONTROLS
-    daily_ai_cost_limit: float = 50.0  # Maximum daily spending on AI API calls (USD)
+    # Default is $10/day — conservative limit to prevent runaway API spend.
+    # Raise via DAILY_AI_COST_LIMIT env var or by editing this value directly.
+    # e.g. export DAILY_AI_COST_LIMIT=25  (for more aggressive scanning)
+    daily_ai_cost_limit: float = field(default_factory=lambda: float(os.getenv("DAILY_AI_COST_LIMIT", "10.0")))
     enable_daily_cost_limiting: bool = True  # Enable daily cost limits
     sleep_when_limit_reached: bool = True  # Sleep until next day when limit reached
 


### PR DESCRIPTION
## Problem

Closes #30 — the `movement_prediction` strategy was burning through the xAI API budget because:
1. `daily_ai_cost_limit` defaulted to **$50/day** — way too high for most users.
2. The `search()` method in `xai_client.py` did **not** check daily limits before calling the xAI Live Search API, so the guard in `_make_completion_request()` didn't apply to search calls.

## Changes

### `src/config/settings.py`
- Lowered `daily_ai_cost_limit` default from **$50 → $10/day**
- Now respects the `DAILY_AI_COST_LIMIT` env var so users can raise it without touching code
- Added comment explaining the knob

### `src/clients/xai_client.py`
- Added `_check_daily_limits()` call at the **top** of `search()`, before any API call is attempted
- Returns a fallback context string (no API call) when the limit is hit
- Aligned `DailyUsageTracker.daily_limit` default to $10 to match

### `README.md`
- Updated the feature bullet to reflect the new default
- Added a dedicated callout block explaining:
  - `DAILY_AI_COST_LIMIT` env var usage
  - How `scan_interval_seconds` and `max_analyses_per_market_per_day` control frequency
  - Why `movement_prediction` is the heavy hitter

## Verification

```bash
# Default is now $10
python3 -c "from src.config.settings import settings; print(settings.trading.daily_ai_cost_limit)"
# → 10.0

# Env var override works
DAILY_AI_COST_LIMIT=25 python3 -c "from src.config.settings import settings; print(settings.trading.daily_ai_cost_limit)"
# → 25.0
```