### PR TITLE
fix: show paper/live mode status clearly and fix false PAUSED state

### DIFF
--- a/beast_mode_dashboard.py
+++ b/beast_mode_dashboard.py
@@ -77,6 +77,14 @@ class BeastModeDashboard:
                 now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 print(f"🚀 BEAST MODE DASHBOARD - {now} 🚀")
                 print("=" * 60)
+
+                # Trading mode banner — always visible so users know their mode
+                paper_mode = getattr(settings.trading, 'paper_trading_mode', True)
+                if paper_mode:
+                    print("📝 PAPER MODE  — orders are simulated, no real money at risk")
+                else:
+                    print("🔴 LIVE MODE   — REAL MONEY IS BEING TRADED ON KALSHI")
+                print("=" * 60)
                 
                 # Get current performance
                 performance = await self.get_comprehensive_performance()
@@ -323,7 +331,12 @@ class BeastModeDashboard:
         
         try:
             available_markets = performance.get('available_markets', 0)
-            
+
+            # Trading mode — always shown so users know paper vs live
+            paper_mode = getattr(settings.trading, 'paper_trading_mode', True)
+            mode_label = "📝 PAPER MODE (simulated)" if paper_mode else "🔴 LIVE MODE (real money)"
+            print(f"💱 Trading Mode: {mode_label}")
+
             # System status indicators
             print(f"📊 Available Markets: {available_markets}")
             print(f"🔌 System Status: {'🟢 OPERATIONAL' if available_markets > 0 else '🔴 LIMITED'}")
@@ -412,6 +425,12 @@ class BeastModeDashboard:
         """Show quick performance summary."""
         print("🚀 BEAST MODE SUMMARY 🚀")
         print("=" * 40)
+
+        # Trading mode banner
+        paper_mode = getattr(settings.trading, 'paper_trading_mode', True)
+        mode_label = "📝 PAPER MODE (simulated)" if paper_mode else "🔴 LIVE MODE (real money)"
+        print(f"💱 Trading Mode: {mode_label}")
+        print()
         
         performance = await self.get_comprehensive_performance()
         

--- a/src/jobs/evaluate.py
+++ b/src/jobs/evaluate.py
@@ -101,6 +101,13 @@ async def analyze_ai_costs(db_manager: DatabaseManager) -> Dict:
     xai_requests_today = xai_tracker["request_count"] if xai_tracker else 0
     trading_paused = (xai_tracker["is_exhausted"] if xai_tracker else False)
 
+    # Guard against false-positive "paused" state: if no requests have been
+    # made today and cost is $0, the tracker cannot legitimately be exhausted
+    # (e.g. stale pickle, first-boot race condition). Clear the flag so the
+    # dashboard doesn't show "PAUSED — DAILY LIMIT REACHED" on a fresh day.
+    if trading_paused and xai_requests_today == 0 and xai_cost_today == 0.0:
+        trading_paused = False
+
     # Use the higher of DB cost vs. pickle cost (DB is authoritative going
     # forward; pickle is the fallback for backwards-compat).
     db_today_cost = daily_costs[today]['cost']
@@ -270,8 +277,11 @@ async def run_evaluation():
         budget_utilization = daily_cost / actual_limit if actual_limit else 0
         trading_paused = cost_analysis.get('trading_paused', False)
         
+        xai_requests_today = cost_analysis.get('xai_requests_today', 0)
         health_status = "🟢 HEALTHY"
-        if trading_paused:
+        # Only mark as paused when actual usage confirms the limit was reached.
+        # Avoid false-positive when 0 requests and $0 cost (stale pickle / fresh day).
+        if trading_paused and (daily_cost > 0 or xai_requests_today > 0):
             health_status = "🔴 PAUSED — DAILY LIMIT REACHED"
         elif budget_utilization > 0.9:
             health_status = "🔴 OVER BUDGET"

--- a/src/paper/dashboard.py
+++ b/src/paper/dashboard.py
@@ -92,11 +92,14 @@ def generate_html(output_path: str = None) -> str:
   .neg {{ color: var(--red); }}
   .table-wrap {{ overflow-x: auto; }}
   a {{ color: var(--blue); text-decoration: none; }}
+  .mode-banner {{ background: #1c2a1c; border: 1px solid var(--green); border-radius: 8px;
+                   padding: .6rem 1rem; margin-bottom: 1rem; color: var(--green); font-size: .9rem; }}
   footer {{ margin-top: 2rem; text-align: center; color: #484f58; font-size: .8rem; }}
 </style>
 </head>
 <body>
 <h1>📊 Paper Trading Dashboard</h1>
+<div class="mode-banner">📝 PAPER MODE — All positions and P&amp;L are <strong>simulated</strong>. No real money is at risk.</div>
 <p class="subtitle">Kalshi AI Trading Bot — Signal tracker &amp; hypothetical P&amp;L · Updated {now}</p>
 
 <div class="stats">


### PR DESCRIPTION
## Summary

Fixes #29 — System status isn't visible in paper mode.

## Changes

### 1. `beast_mode_dashboard.py` — Paper/Live mode indicator
- Added a prominent **📝 PAPER MODE** or **🔴 LIVE MODE** banner immediately after the dashboard header, always visible on every refresh cycle
- Added the same indicator to the `_display_system_health()` section under `💱 Trading Mode:`
- Added the mode indicator to `show_summary()` as well
- All three spots read `settings.trading.paper_trading_mode` so they reflect the actual runtime mode

### 2. `src/paper/dashboard.py` — Paper mode banner in HTML dashboard
- Added a clearly visible green banner: *"📝 PAPER MODE — All positions and P&L are simulated. No real money is at risk."* at the top of the static HTML dashboard
- Added corresponding CSS (`.mode-banner`) for styling

### 3. `src/jobs/evaluate.py` — Fix false "PAUSED — DAILY LIMIT REACHED"
- **Root cause:** A stale pickle file or first-boot race condition could leave `is_exhausted=True` in the `DailyUsageTracker` even when `xai_requests_today=0` and `xai_cost_today=$0.00`
- **Fix in `analyze_ai_costs()`:** Clear `trading_paused` flag when `xai_requests_today == 0 and xai_cost_today == 0.0`
- **Fix in `run_evaluation()`:** Same guard — only emit `health_status = "PAUSED — DAILY LIMIT REACHED"` when `daily_cost > 0 or xai_requests_today > 0`

## Testing
- Verified changes compile cleanly (no import changes)
- Logic is additive/defensive — no existing behaviour broken for non-zero usage
