### PR TITLE
fix: migrate to Kalshi API v2 dollar-denominated price fields

### DIFF
--- a/scripts/performance_analysis.py
+++ b/scripts/performance_analysis.py
@@ -6,6 +6,7 @@ sys.path.append('.')
 from src.clients.kalshi_client import KalshiClient
 from src.utils.database import DatabaseManager
 from src.clients.xai_client import XAIClient
+from src.utils.market_prices import get_market_prices
 import aiosqlite
 from datetime import datetime, timedelta
 
@@ -89,10 +90,11 @@ async def comprehensive_analysis():
                 try:
                     market_data = await kalshi_client.get_market(ticker)
                     market_info = market_data.get('market', {})
+                    yes_bid, yes_ask, no_bid, no_ask = get_market_prices(market_info)
                     if quantity > 0:  # Long position
-                        current_price = (market_info.get('yes_bid', 0) + market_info.get('yes_ask', 100)) / 2 / 100
-                    else:  # Short position  
-                        current_price = (market_info.get('no_bid', 0) + market_info.get('no_ask', 100)) / 2 / 100
+                        current_price = (yes_bid + yes_ask) / 2
+                    else:  # Short position
+                        current_price = (no_bid + no_ask) / 2
                     position_value = abs(quantity) * current_price
                     total_position_value += position_value
                 except:

--- a/scripts/sync_positions.py
+++ b/scripts/sync_positions.py
@@ -24,6 +24,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.clients.kalshi_client import KalshiClient
 from src.utils.database import DatabaseManager, Position, TradeLog
 from src.utils.logging_setup import get_trading_logger
+from src.utils.market_prices import get_market_prices
 
 logger = get_trading_logger(__name__)
 
@@ -74,12 +75,13 @@ async def sync_positions_to_database():
                         market_info = market_data['market']
                         
                         # Determine side and current price
+                        yes_bid, yes_ask, no_bid, no_ask = get_market_prices(market_info)
                         if position_count > 0:  # YES position
                             side = 'YES'
-                            current_price = (market_info.get('yes_bid', 0) + market_info.get('yes_ask', 100)) / 2 / 100
+                            current_price = (yes_bid + yes_ask) / 2
                         else:  # NO position
                             side = 'NO'
-                            current_price = (market_info.get('no_bid', 0) + market_info.get('no_ask', 100)) / 2 / 100
+                            current_price = (no_bid + no_ask) / 2
                         
                         # Create database position
                         position = Position(

--- a/src/jobs/execute.py
+++ b/src/jobs/execute.py
@@ -12,6 +12,7 @@ from src.utils.database import DatabaseManager, Position
 from src.config.settings import settings
 from src.utils.logging_setup import get_trading_logger
 from src.clients.kalshi_client import KalshiClient, KalshiAPIError
+from src.utils.market_prices import get_market_prices
 
 async def execute_position(
     position: Position, 
@@ -58,19 +59,22 @@ async def execute_position(
             
             # Add the appropriate price field based on side
             # For market orders, we use the ask price (what we're willing to pay)
+            # get_market_prices normalizes both API v2 (dollar floats) and legacy (cent ints)
+            # to dollar values (0.0–1.0). place_order expects cents (int), so multiply by 100.
+            _yes_bid, yes_ask_dollars, _no_bid, no_ask_dollars = get_market_prices(market)
             if side_lower == "yes":
-                yes_ask = market.get('yes_ask', 0)
-                if yes_ask > 0:
-                    order_params["yes_price"] = yes_ask
+                yes_ask_cents = int(round(yes_ask_dollars * 100))
+                if yes_ask_cents > 0:
+                    order_params["yes_price"] = yes_ask_cents
                 else:
-                    logger.error(f"No valid yes_ask price for {position.market_id}: {yes_ask}")
+                    logger.error(f"No valid yes_ask price for {position.market_id}: {yes_ask_dollars}")
                     return False
             else:  # side_lower == "no"
-                no_ask = market.get('no_ask', 0)
-                if no_ask > 0:
-                    order_params["no_price"] = no_ask
+                no_ask_cents = int(round(no_ask_dollars * 100))
+                if no_ask_cents > 0:
+                    order_params["no_price"] = no_ask_cents
                 else:
-                    logger.error(f"No valid no_ask price for {position.market_id}: {no_ask}")
+                    logger.error(f"No valid no_ask price for {position.market_id}: {no_ask_dollars}")
                     return False
             
             logger.info(f"Placing order with params: {order_params}")

--- a/src/strategies/portfolio_optimization.py
+++ b/src/strategies/portfolio_optimization.py
@@ -36,6 +36,7 @@ from src.clients.kalshi_client import KalshiClient
 from src.clients.xai_client import XAIClient
 from src.config.settings import settings
 from src.utils.logging_setup import get_trading_logger
+from src.utils.market_prices import get_market_prices
 
 
 @dataclass
@@ -1138,10 +1139,9 @@ async def _evaluate_immediate_trade(
             # FIXED: Extract from nested 'market' object in API response
             market_info = market_data.get('market', {})
             market_status = market_info.get('status')
-            yes_ask = market_info.get('yes_ask', 0)
-            no_ask = market_info.get('no_ask', 0)
+            _yes_bid, yes_ask, _no_bid, no_ask = get_market_prices(market_info)
             
-            logger.info(f"🔍 Market validation for {opportunity.market_id}: status={market_status}, YES={yes_ask}¢, NO={no_ask}¢")
+            logger.info(f"🔍 Market validation for {opportunity.market_id}: status={market_status}, YES={yes_ask:.4f}, NO={no_ask:.4f}")
             
             # FIXED: Kalshi uses 'active' for tradeable markets, not 'open'
             if market_status not in ['active', 'open']:
@@ -1149,7 +1149,7 @@ async def _evaluate_immediate_trade(
                 return
             
             if not (yes_ask and no_ask and yes_ask > 0 and no_ask > 0):
-                logger.warning(f"⏭️ Skipping {opportunity.market_id} - No valid prices (YES={yes_ask}¢, NO={no_ask}¢)")
+                logger.warning(f"⏭️ Skipping {opportunity.market_id} - No valid prices (YES={yes_ask:.4f}, NO={no_ask:.4f})")
                 return
                 
             logger.info(f"✅ Market validation passed for {opportunity.market_id} - Status: {market_status}, proceeding with trade!")

--- a/src/utils/market_prices.py
+++ b/src/utils/market_prices.py
@@ -1,0 +1,39 @@
+"""
+Market price normalization utilities.
+
+Kalshi API v2 changed price fields from cent-based integers
+(yes_ask, yes_bid, no_ask, no_bid) to dollar-based floats
+(yes_ask_dollars, yes_bid_dollars, no_ask_dollars, no_bid_dollars).
+
+This module provides a single helper that normalizes both formats
+to dollar values (0.0–1.0).
+"""
+from typing import Dict, Any, Tuple
+
+
+def get_market_prices(market_info: Dict[str, Any]) -> Tuple[float, float, float, float]:
+    """
+    Extract and normalize market prices from a Kalshi API market object.
+
+    Supports both:
+      - API v2: yes_bid_dollars / yes_ask_dollars / no_bid_dollars / no_ask_dollars
+                (float, already in dollars, e.g. 0.52 = $0.52)
+      - Legacy: yes_bid / yes_ask / no_bid / no_ask
+                (integer cents, e.g. 52 = $0.52)
+
+    Returns:
+        (yes_bid, yes_ask, no_bid, no_ask) all as dollar floats in [0.0, 1.0].
+    """
+    if "yes_bid_dollars" in market_info:
+        yes_bid = float(market_info.get("yes_bid_dollars", 0) or 0)
+        yes_ask = float(market_info.get("yes_ask_dollars", 0) or 0)
+        no_bid  = float(market_info.get("no_bid_dollars",  0) or 0)
+        no_ask  = float(market_info.get("no_ask_dollars",  0) or 0)
+    else:
+        # Legacy API: values in cents (0–100)
+        yes_bid = (market_info.get("yes_bid", 0) or 0) / 100
+        yes_ask = (market_info.get("yes_ask", 0) or 0) / 100
+        no_bid  = (market_info.get("no_bid",  0) or 0) / 100
+        no_ask  = (market_info.get("no_ask",  0) or 0) / 100
+
+    return yes_bid, yes_ask, no_bid, no_ask


### PR DESCRIPTION
## Problem

Kalshi API v2 renamed price fields from cent-based integers (`yes_ask`, `yes_bid`, `no_ask`, `no_bid`) to dollar-based floats (`yes_ask_dollars`, `yes_bid_dollars`, `no_ask_dollars`, `no_bid_dollars`). The old fields now return `0`, causing trade validation to always fail with `YES=0¢, NO=0¢`.

Closes #40

## Solution

Added a shared helper `src/utils/market_prices.py` → `get_market_prices(market_info)` that:
- Detects API v2 by presence of `yes_bid_dollars` key
- Returns normalized dollar values (0.0–1.0) for both v2 and legacy APIs
- Used in all 4 affected files for consistency

## Files changed

| File | Change |
|------|--------|
| `src/utils/market_prices.py` | **New** — `get_market_prices()` helper, normalizes both API formats |
| `src/jobs/execute.py` | Use helper; convert back to cents (×100) for `place_order` which expects int cents |
| `src/strategies/portfolio_optimization.py` | Use helper; update log messages (drop `¢`, use 4-decimal dollar format) |
| `scripts/performance_analysis.py` | Use helper; removes manual `/100` normalization |
| `scripts/sync_positions.py` | Use helper; removes manual `/100` normalization |

## Notes
- `place_order` in `kalshi_client.py` still expects cents (int); `execute.py` multiplies dollar value × 100 before passing
- `src/jobs/ingest.py` and `src/strategies/quick_flip_scalping.py` already handled both formats — this PR brings the remaining files in line