### PR TITLE
fix: filter collection tickers and add price sanity checks (#42)

### DIFF
--- a/src/jobs/execute.py
+++ b/src/jobs/execute.py
@@ -64,18 +64,24 @@ async def execute_position(
             _yes_bid, yes_ask_dollars, _no_bid, no_ask_dollars = get_market_prices(market)
             if side_lower == "yes":
                 yes_ask_cents = int(round(yes_ask_dollars * 100))
-                if yes_ask_cents > 0:
-                    order_params["yes_price"] = yes_ask_cents
-                else:
-                    logger.error(f"No valid yes_ask price for {position.market_id}: {yes_ask_dollars}")
+                if not (1 <= yes_ask_cents <= 99):
+                    logger.warning(
+                        f"Price sanity check failed for {position.market_id}: "
+                        f"yes_ask_cents={yes_ask_cents} is outside valid range 1–99 "
+                        f"(raw yes_ask_dollars={yes_ask_dollars:.4f}). Skipping order."
+                    )
                     return False
+                order_params["yes_price"] = yes_ask_cents
             else:  # side_lower == "no"
                 no_ask_cents = int(round(no_ask_dollars * 100))
-                if no_ask_cents > 0:
-                    order_params["no_price"] = no_ask_cents
-                else:
-                    logger.error(f"No valid no_ask price for {position.market_id}: {no_ask_dollars}")
+                if not (1 <= no_ask_cents <= 99):
+                    logger.warning(
+                        f"Price sanity check failed for {position.market_id}: "
+                        f"no_ask_cents={no_ask_cents} is outside valid range 1–99 "
+                        f"(raw no_ask_dollars={no_ask_dollars:.4f}). Skipping order."
+                    )
                     return False
+                order_params["no_price"] = no_ask_cents
             
             logger.info(f"Placing order with params: {order_params}")
             order_response = await kalshi_client.place_order(**order_params)

--- a/src/jobs/ingest.py
+++ b/src/jobs/ingest.py
@@ -40,8 +40,24 @@ async def process_and_queue_markets(
             no_price = (no_bid + no_ask) / 2
         else:
             # Legacy API: values in cents (0-100)
-            yes_price = (market_data.get("yes_bid", 0) + market_data.get("yes_ask", 0)) / 2 / 100
-            no_price = (market_data.get("no_bid", 0) + market_data.get("no_ask", 0)) / 2 / 100
+            yes_ask = market_data.get("yes_ask", 0) / 100
+            no_ask = market_data.get("no_ask", 0) / 100
+            yes_price = (market_data.get("yes_bid", 0) / 100 + yes_ask) / 2
+            no_price = (market_data.get("no_bid", 0) / 100 + no_ask) / 2
+
+        # Skip collection/aggregate tickers: both yes_ask and no_ask near $1.00
+        # (e.g. KXMVECROSSCATEGORY-*, KXMVESPORTSMULTIGAMEEXTENDED-*).
+        # The Kalshi API returns yes_ask=1.0000 and no_ask=1.0000 for these
+        # multi-event container markets — they are NOT real binary markets and
+        # cannot be traded.
+        _COLLECTION_THRESHOLD = 0.98
+        if yes_ask >= _COLLECTION_THRESHOLD and no_ask >= _COLLECTION_THRESHOLD:
+            logger.warning(
+                f"Skipping collection/aggregate market {market_data['ticker']}: "
+                f"yes_ask={yes_ask:.4f}, no_ask={no_ask:.4f} "
+                f"(both >= {_COLLECTION_THRESHOLD}, not a tradeable binary market)"
+            )
+            continue
 
         # Kalshi API v2 uses volume_fp (string/float) instead of volume (int)
         volume = int(float(market_data.get("volume_fp", 0) or market_data.get("volume", 0) or 0))


### PR DESCRIPTION
## Problem

Collection/aggregate tickers (e.g. `KXMVECROSSCATEGORY-*`, `KXMVESPORTSMULTIGAMEEXTENDED-*`) return `yes_ask_dollars: 1.0000` and `no_ask_dollars: 1.0000` from the Kalshi API. These are multi-event container markets — not directly tradeable binary markets.

When the bot attempts to place orders on these tickers, Kalshi returns HTTP 400 `invalid_price` because `yes_price`/`no_price` must be between 1–99 cents for valid binary markets.

## Fix

**`src/jobs/ingest.py`** — Filter at ingestion:
- Skip any market where both `yes_ask >= 0.98` AND `no_ask >= 0.98` (collection ticker signature)
- Applies to both API v2 (dollar-based) and legacy (cent-based) paths
- These markets never reach the DB or analysis queue

**`src/jobs/execute.py`** — Safety net at execution:
- Replace loose `> 0` price validation with strict `1 <= cents <= 99` range check
- If a market somehow slips through ingestion, the order is rejected before hitting the API
- Clear warning logs with raw price values for debugging

Closes #42