### PR TITLE
[codex] add agent docs and testing runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+This repository is intended to be worked on by both humans and AI agents.
+Use this file as the first-stop operating guide.
+
+## Core Rules
+
+- Work on a feature branch, not directly on `main`.
+- Make one coherent change at a time.
+- Keep secrets out of commits, logs, docs, and screenshots.
+- Prefer small, reviewable pull requests with a clear test summary.
+- If you change behavior, update the docs and tests together.
+
+## Safe Editing Workflow
+
+1. Inspect the current code and docs first.
+2. Make the smallest change that solves the task.
+3. Run the relevant tests locally.
+4. Summarize behavior changes and test results in the PR.
+5. Push the branch and open a PR.
+
+## Local Entry Points
+
+- `python cli.py run --paper` starts the paper bot.
+- `python cli.py dashboard` opens the dashboard.
+- `python cli.py status` prints portfolio and position status.
+- `python paper_trader.py --loop` runs the signal logger in a loop.
+- `python paper_trader.py --dashboard` regenerates the paper dashboard.
+
+## Testing Expectations
+
+- Run focused tests for the area you touched.
+- Run the broader repo test set before opening a PR if the change is cross-cutting.
+- Include both backend and frontend checks when the change touches the dashboard.
+- Never rely on manual inspection alone if a test can verify the behavior.
+
+## PR Expectations
+
+- Explain what changed.
+- Explain why the change was needed.
+- List all relevant test commands and their results.
+- Mention any known follow-up work or limitations.
+- Include screenshots only when they add value for UI changes.
+
+## For AI Agents
+
+- Prefer non-mutating exploration first.
+- Do not overwrite user work.
+- Keep assumptions explicit.
+- If a task needs a new file or doc, put it in the repo rather than leaving it in chat.
+- When the repo has a dedicated future-plan document, update that instead of inventing a parallel plan.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,15 @@ If you find a security vulnerability:
 - **Configuration docs**: Settings and configuration
 - **Tutorials**: Step-by-step guides
 
+### Project Docs
+
+Use these repo docs as the source of truth for operation, testing, and AI-assisted development:
+
+- [Runbook](docs/RUNBOOK.md) — how to start, stop, and verify the bot
+- [Testing Guide](docs/TESTING.md) — what to test and what to report in a PR
+- [AI Collaboration Guide](docs/AI_COLLABORATION.md) — branch, PR, and agent workflow
+- [AGENTS.md](AGENTS.md) — repo-wide operating rules for humans and AI agents
+
 ## 🏷️ Versioning
 
 We use [Semantic Versioning](https://semver.org/):

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Five frontier LLMs debate every trade. The system only enters when they agree.
 
-[Quick Start](#-quick-start) · [Features](#-features) · [How It Works](#-how-it-works) · [Configuration](#configuration-reference) · [Contributing](CONTRIBUTING.md) · [Kalshi API Docs](https://trading-api.readme.io/reference/getting-started)
+[Quick Start](#-quick-start) · [Features](#-features) · [How It Works](#-how-it-works) · [Configuration](#configuration-reference) · [Contributing](CONTRIBUTING.md) · [Runbook](docs/RUNBOOK.md) · [Testing](docs/TESTING.md) · [AI Collaboration](docs/AI_COLLABORATION.md) · [Kalshi API Docs](https://trading-api.readme.io/reference/getting-started)
 
 </div>
 

--- a/docs/AI_COLLABORATION.md
+++ b/docs/AI_COLLABORATION.md
@@ -1,0 +1,47 @@
+# AI Collaboration Guide
+
+This repository is designed to be workable by coding assistants as well as humans.
+
+## Agent Workflow
+
+1. Read `AGENTS.md` and the relevant code path first.
+2. Inspect existing docs before creating new ones.
+3. Keep changes scoped to one concern when possible.
+4. Run the appropriate tests before claiming success.
+5. Open a PR with a concise explanation and a real test summary.
+
+## Branching and PRs
+
+- Always work on a branch.
+- Do not push directly to `main`.
+- Use a PR for every code change.
+- Keep PRs focused and easy to review.
+
+Suggested workflow:
+
+```bash
+git checkout -b codex/<short-topic>
+pytest
+gh pr create --draft --fill
+```
+
+## What to Include in a PR
+
+- Short description of the user-visible change.
+- Technical summary of the implementation.
+- Commands used for testing.
+- Test results, including failures fixed during the work.
+- Follow-up work if the change only solves part of the problem.
+
+## When Changing Behavior
+
+- Update docs and tests together.
+- Call out any compatibility impact.
+- If the change affects the dashboard or runtime behavior, include a browser check.
+- If the change affects signal quality or performance, include timing or throughput observations when available.
+
+## Safety
+
+- Never leak API keys or private credentials.
+- Do not overwrite work you did not create.
+- If the repo has a stale process or old branch tip, verify the running state before assuming the code is live.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,54 @@
+# Runbook
+
+This repo ships a paper-trading bot plus a dashboard and a separate paper signal logger.
+Use this guide for day-to-day operation and for helping new contributors or agents get oriented quickly.
+
+## Prerequisites
+
+- Python 3.12+
+- Kalshi API credentials if you want live market access
+- xAI / OpenRouter credentials if you want the LLM-backed decision flow
+- A virtual environment with `requirements.txt` installed
+
+## Common Commands
+
+```bash
+python cli.py run --paper
+python cli.py dashboard
+python cli.py status
+python paper_trader.py
+python paper_trader.py --loop
+python paper_trader.py --dashboard
+python paper_trader.py --stats
+```
+
+## What Each Mode Does
+
+- `cli.py run --paper` runs the bot in paper mode.
+- `cli.py run --live` runs the trading flow against live execution.
+- `cli.py dashboard` launches the Streamlit monitoring UI.
+- `paper_trader.py` logs paper signals to SQLite and builds the static dashboard.
+- `paper_trader.py --loop` keeps scanning on a schedule.
+
+## Recommended Operational Sequence
+
+1. Pull the latest branch or check out the PR branch.
+2. Create or activate the virtual environment.
+3. Confirm environment variables are present.
+4. Run the targeted test subset for the change.
+5. Start the paper bot.
+6. Open the dashboard in a browser.
+7. Verify status, signals, and error panels after the first cycle.
+
+## Restart and Recovery
+
+- If a backend or scheduler process is restarted, confirm the bot version and loop state before resuming analysis.
+- After a restart, verify the dashboard has reconnected and is showing fresh data.
+- If the signal stack is stale, check the latest logs before changing code.
+
+## Repo Hygiene
+
+- Do not commit API keys or private credentials.
+- Keep generated artifacts out of source control unless they are intentionally checked in.
+- If you add a new operational workflow, document the exact command and expected outcome here.
+

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,64 @@
+# Testing Guide
+
+This document is the canonical testing checklist for the repo.
+It is written so that both humans and AI coding assistants can use it directly.
+
+## Test Strategy
+
+- Run focused tests for the code you touched.
+- Run the broader suite if the change affects shared behavior.
+- Prefer deterministic unit tests for parsing, routing, and scoring logic.
+- Use integration tests for pipeline and orchestration changes.
+- Use browser-based checks when validating the dashboard.
+
+## Backend Tests
+
+Typical commands:
+
+```bash
+pytest tests/test_decide.py
+pytest tests/test_ensemble.py
+pytest tests/test_agents.py
+pytest tests/test_live_order_execution.py
+pytest tests/test_end_to_end.py
+```
+
+If you changed core orchestration or risk logic, run the full suite:
+
+```bash
+pytest
+```
+
+## Dashboard / Browser Checks
+
+- Start the bot or paper signal logger.
+- Open the dashboard in a browser.
+- Verify the key panels show live updates.
+- Check the browser console for errors and warnings.
+
+If you are validating UI changes, capture the browser state before and after the first update cycle.
+
+## What to Verify
+
+- Paper mode runs without exceptions.
+- Live mode still respects risk and category filters.
+- News and sentiment paths can fail without breaking the decision loop.
+- Paper signals are logged and settled correctly.
+- Dashboard stats match the underlying SQLite or API-backed state.
+
+## Performance Checks
+
+When a change touches scanning, aggregation, or model routing:
+
+- Measure whether the change increases end-to-end decision latency.
+- Confirm the bot still completes a full analysis cycle within the expected interval.
+- Check that cache TTLs are respected.
+- Confirm the new code does not introduce repeated or duplicate work.
+
+## PR Acceptance Criteria
+
+- Tests that cover the changed behavior pass locally.
+- The PR description lists the exact commands run and the results.
+- If any test was skipped, the reason is documented.
+- Any new failure mode has a clear fallback or a logged error path.
+

--- a/futureplans/ideas_feed_scraper_plan.md
+++ b/futureplans/ideas_feed_scraper_plan.md
@@ -1,0 +1,74 @@
+# Browser-Backed Ideas Feed Scraper with Trader Identity Resolution
+
+## Summary
+Build a browser-backed scraper for `https://kalshi.com/ideas/feed` that is read-only and feeds mirror discovery, not trading. It should extract each public trade post and then resolve the trader identity before anything goes downstream.
+
+For trader discovery, use a two-stage policy:
+- Preferred: explicit profile link or canonical handle from the feed row
+- Fallback: fuzzy match the display name against an existing trader watchlist / known aliases when the feed does not expose a clean handle
+
+Anything low-confidence stays as an unconfirmed candidate and does not auto-promote into the mirror set.
+
+## Key Changes
+- Add a browser-backed feed scraper worker.
+  - Load the Ideas feed in a real browser session.
+  - Extract visible public trade rows/cards.
+  - Filter to trades over `$100`.
+  - Normalize each row into a structured record: market, side, size, timestamp, visible trader text, and source URL.
+
+- Add trader identity resolution.
+  - If the feed exposes a profile link or canonical handle, use that as the trader identity.
+  - If not, fall back to fuzzy matching on display name / alias / prior feed mentions.
+  - Persist the identity result with a confidence score and evidence trail.
+  - Keep explicit vs fuzzy matches distinguishable in storage and in the UI.
+
+- Integrate into mirror discovery.
+  - Feed-derived trader identities populate a candidate mirror watchlist.
+  - The main bot can score those candidates for relevance and historical performance.
+  - The scraper output remains advisory only; it does not trigger trades directly.
+
+- Make it safe to run alongside the bot.
+  - Put the scraper on its own cadence and TTL.
+  - Cache results and back off on checkpoint / rate-limit responses.
+  - If the feed is blocked or stale, the bot keeps running with the other signal sources.
+
+- Use browser MCP for development validation only.
+  - Use Chrome DevTools MCP to verify the live DOM, selectors, and rendered rows.
+  - Do not depend on MCP at runtime.
+  - If the page structure changes, fail closed and mark the source stale rather than guessing.
+
+## Runtime / Integration Shape
+- Input: public Ideas feed page rendered in a browser.
+- Output: normalized feed items plus resolved trader identities.
+- Downstream use:
+  - mirror candidate discovery
+  - trader relevance scoring
+  - source-health reporting
+- Identity policy:
+  - explicit profile link / handle wins
+  - fuzzy matching is allowed only as fallback
+  - low-confidence identity stays unconfirmed until reinforced by later feed evidence
+
+## Test Plan
+- Browser validation:
+  - use Chrome DevTools MCP to confirm the feed renders and selectors still match the DOM
+  - verify rows expose trader text and, when available, a profile link/handle
+- Unit tests:
+  - parse and normalize feed rows
+  - resolve explicit handles correctly
+  - fuzzy-match display names when no handle is present
+  - reject ambiguous or low-confidence identity matches
+- Integration tests:
+  - feed output flows into mirror discovery
+  - scraper outages do not block trading
+  - cached data is reused until TTL expires
+- Main-bot tests:
+  - live decision path still works when the Ideas feed is unavailable
+  - feed-derived traders appear as advisory candidates only
+  - no direct-trade coupling is introduced
+
+## Assumptions
+- The feed is publicly visible but checkpointed, so scraping must be browser-backed and conservative.
+- The `Handle + fuzzy` policy is the right balance here: explicit identity when possible, fallback matching when needed, but no automatic promotion on weak evidence.
+- Chrome DevTools MCP is for development and test verification, not the production runtime.
+- If the feed structure changes, the scraper should fail closed and report stale/unusable rather than inventing trader identities.


### PR DESCRIPTION
## Summary
Add repository-facing documentation for humans and AI agents: a repo-level `AGENTS.md`, a runbook, a testing guide, and an AI collaboration guide. Also add a future-plan markdown file for the Ideas feed scraper work.

## What changed
- Added `AGENTS.md` with repo operating rules for humans and AI agents.
- Added `docs/RUNBOOK.md` with commands and recovery steps.
- Added `docs/TESTING.md` with backend, browser, and PR testing guidance.
- Added `docs/AI_COLLABORATION.md` with branch / PR / agent workflow guidance.
- Linked the new docs from `README.md` and `CONTRIBUTING.md`.
- Added `futureplans/ideas_feed_scraper_plan.md` for later implementation work.

## Why
The repo needed a single place for operational guidance so other contributors and coding assistants can run the bot, test it, and open PRs without re-deriving the workflow.

## Testing
- Documentation-only change.
- No code paths were modified beyond docs and navigation links.
- No runtime tests were needed.

## Notes
- The PR is intentionally scoped to docs and planning artifacts only.
- The implementation work for the Ideas feed scraper remains in the future-plan file.
