### PR TITLE
fix(ci): add tests/__init__.py so bare pytest resolves intra-test imports

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+"""Test suite package.
+
+Marking ``tests`` as a package lets sibling modules import shared
+helpers via the ``tests.`` prefix (e.g. ``from tests.test_database import
+TEST_DB``). Without this file, a bare ``pytest`` run — as used in CI —
+fails at collection with ``ModuleNotFoundError: No module named 'tests'``,
+because pytest's default ``prepend`` import mode only puts the project
+root on ``sys.path`` when ``tests`` is an importable package.
+"""


### PR DESCRIPTION
## Problem
CI (`CI / Tests`) fails at **collection**, not in any test:

```
tests/test_decide.py:11: from tests.test_database import load_and_prepare_markets, TEST_DB, FIXTURE_PATH
E   ModuleNotFoundError: No module named 'tests'
```

The workflow runs the `pytest` console script. Under pytest's default `prepend` import mode, the project root is only added to `sys.path` when `tests/` is an importable package. Because `tests/__init__.py` was missing, the `tests.` prefix used by several modules (`test_decide`, `test_execute`, `test_end_to_end`) didn't resolve, and the whole run aborted. It passed locally only because `python -m pytest` puts the CWD on `sys.path` (making `tests` an implicit namespace package).

## Fix
Add an empty (documented) `tests/__init__.py`. This makes `tests` a real package — matching **every** existing intra-test import — and puts the project root on `sys.path` under prepend mode. No test files changed.

## Verification
Faithful CI replica (Python 3.12 + `pip install -e ".[dev]"` + bare `pytest`):
- **Before:** `1 error during collection` → exit 2 (reproduces CI exactly)
- **After:** `84 passed, 8 skipped, 0 collection errors` (the 8 skipped are the `live` tests, correctly gated by `RUN_LIVE_TESTS`)