### PR TITLE
fix(optimizer): correct correlation-matrix indexing in portfolio metrics

### DIFF
--- a/src/strategies/portfolio/optimizer.py
+++ b/src/strategies/portfolio/optimizer.py
@@ -638,7 +638,20 @@ class AdvancedPortfolioOptimizer:
             # Portfolio volatility
             n = len(allocated_opps)
             if n > 1:
-                allocated_corr_matrix = correlation_matrix[:n, :n]
+                # `correlation_matrix` was built over ALL `opportunities` in
+                # their original order, so row/col i belongs to opportunities[i].
+                # Index by each allocated market's actual position — slicing
+                # [:n, :n] would pair allocated markets with whichever markets
+                # happened to be first in the input, corrupting the covariance
+                # (and therefore volatility/Sharpe/VaR) whenever the allocated
+                # set isn't the leading n.
+                index_by_id = {opp.market_id: i for i, opp in enumerate(opportunities)}
+                allocated_indices = [index_by_id[opp.market_id] for opp in allocated_opps]
+                if max(allocated_indices) < correlation_matrix.shape[0]:
+                    allocated_corr_matrix = correlation_matrix[np.ix_(allocated_indices, allocated_indices)]
+                else:
+                    # Defensive: matrix smaller than expected — drop cross-terms.
+                    allocated_corr_matrix = np.eye(n)
                 covariance_matrix = np.outer(volatilities, volatilities) * allocated_corr_matrix
                 portfolio_vol = np.sqrt(np.dot(weights, np.dot(covariance_matrix, weights)))
             else:

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -9,6 +9,7 @@ contract.
 All tests are pure math: no network, no credentials, CI-safe.
 """
 
+import numpy as np
 import pytest
 from unittest.mock import Mock
 
@@ -239,3 +240,56 @@ class TestKellyFractionsKCE:
         )
         result = opt._calculate_kelly_fractions([opp])
         assert result["TEST-MKT"] == pytest.approx(0.25)
+
+
+# ---------------------------------------------------------------------------
+# PortfolioOptimizer._calculate_portfolio_metrics  [correlation indexing]
+# ---------------------------------------------------------------------------
+
+class TestPortfolioMetricsCorrelationIndexing:
+    """The correlation matrix is built over ALL opportunities in input order.
+
+    When only a SUBSET is allocated, the portfolio metrics must pair each
+    allocated market with its OWN correlations — not the top-left n x n block
+    of the full matrix. Slicing [:n, :n] silently pairs each allocated market
+    with whichever market happened to be first in the input, corrupting
+    volatility/Sharpe/VaR whenever the allocated set isn't the leading n.
+    """
+
+    def test_uses_allocated_markets_own_correlations(self):
+        opt = make_optimizer()
+        opt.total_capital = 10_000
+
+        # Three opportunities in input order A, B, C.
+        a = make_opportunity(market_id="A", volatility=0.10)
+        b = make_opportunity(market_id="B", volatility=0.20)
+        c = make_opportunity(market_id="C", volatility=0.30)
+        opportunities = [a, b, c]
+
+        # Correlation matrix over [A, B, C]. The A-B block (top-left, what the
+        # bug uses) is HIGHLY correlated (0.9); the B-C block (correct for an
+        # allocation of B and C) is weakly correlated (0.2).
+        corr = np.array(
+            [
+                [1.0, 0.9, 0.1],
+                [0.9, 1.0, 0.2],
+                [0.1, 0.2, 1.0],
+            ]
+        )
+
+        # Allocate to B and C only — i.e. NOT the leading n markets.
+        allocation = {"B": 0.5, "C": 0.5}
+
+        metrics = opt._calculate_portfolio_metrics(allocation, opportunities, corr)
+
+        w = np.array([0.5, 0.5])
+        vols = np.array([0.20, 0.30])
+        # Correct: pair B,C with their real 0.2 cross-correlation.
+        correct_cov = np.outer(vols, vols) * corr[np.ix_([1, 2], [1, 2])]
+        expected_vol = float(np.sqrt(w @ correct_cov @ w))  # ~0.19621
+        # Buggy: top-left A-B block (0.9 correlation).
+        buggy_cov = np.outer(vols, vols) * corr[:2, :2]
+        buggy_vol = float(np.sqrt(w @ buggy_cov @ w))  # ~0.24393
+
+        assert metrics["portfolio_volatility"] == pytest.approx(expected_vol, rel=1e-9)
+        assert metrics["portfolio_volatility"] != pytest.approx(buggy_vol, rel=1e-6)


### PR DESCRIPTION
## The bug
`AdvancedPortfolioOptimizer._calculate_portfolio_metrics` (`src/strategies/portfolio/optimizer.py`) computed portfolio volatility from the **top-left n×n block** of the correlation matrix:

```python
allocated_corr_matrix = correlation_matrix[:n, :n]   # n = number of ALLOCATED markets
```

But `correlation_matrix` is built over **all** opportunities in input order (row/col `i` ↔ `opportunities[i]`), while `weights`/`volatilities` come from the **filtered, allocated** subset. Unless the allocated markets are exactly the first `n` in input order, every allocated market gets paired with the **wrong** market's correlations.

This silently corrupts `portfolio_volatility`, `portfolio_sharpe`, `portfolio_var_95`/`cvar_95`, `diversification_ratio`, and `portfolio_growth_rate` — i.e. the numbers the system reports as its risk assessment.

## The fix
Index the matrix by each allocated market's **actual position** via `np.ix_`, with a defensive fallback if the matrix is unexpectedly small.

## Test (TDD)
Adds the first end-to-end test of `_calculate_portfolio_metrics`. Three markets A,B,C; allocate **B and C only** (not the leading n); the A-B block is 0.9-correlated, the B-C block 0.2-correlated:
- **Before:** `portfolio_volatility = 0.24393` (wrong — A-B block)
- **After:** `portfolio_volatility = 0.19621` (correct — B-C block)

Full suite: **85 passed, 8 skipped** (verified in a Python 3.12 + `pip install -e ".[dev]"` + bare `pytest` replica).

> Context: surfaced by a full-repo review. Isolated from the docs/config changes on purpose — this touches live risk math and should be reviewable/revertable on its own.