### PR TITLE
chore: capture surface + scrub stale multi-model claims

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Turns on the "Sponsor" button across the repo.
+# Activate GitHub Sponsors at https://github.com/sponsors to make it render.
+github: [ryanfrigo]

--- a/README.md
+++ b/README.md
@@ -484,6 +484,6 @@ MIT. See [LICENSE](LICENSE).
 
 <div align="center">
 
-If this is useful to you, a star helps others find it.
+**Found this useful?** ⭐ [Star the repo](https://github.com/ryanfrigo/kalshi-ai-trading-bot) so others can find it · 💬 [Ask or share in Discussions](https://github.com/ryanfrigo/kalshi-ai-trading-bot/discussions) · ❤️ [Sponsor the work](https://github.com/sponsors/ryanfrigo)
 
 </div>

--- a/env.template
+++ b/env.template
@@ -2,7 +2,8 @@
 # Get your API key from: https://trading.kalshi.com/settings/api
 KALSHI_API_KEY=your_kalshi_api_key_here
 
-# OpenRouter API Configuration — ALL models (Claude Sonnet 4.5, GPT-5.4, Gemini 3.1 Pro, DeepSeek V3.2, Grok 4.1 Fast)
+# OpenRouter API Configuration — one key for any model on OpenRouter
+# (the bot calls a single model per decision; choose it in your config)
 # Get your API key from: https://openrouter.ai/keys
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "kalshi-ai-trading-bot"
 version = "2.0.1"
-description = "Multi-model AI trading bot for Kalshi prediction markets"
+description = "A toolkit for building AI-automated trading strategies on Kalshi prediction markets"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"


### PR DESCRIPTION
Low-risk **leak-stoppers** to start capturing the repo's organic search traffic (no code paths touched).

## Changes
| File | Change | Why |
|---|---|---|
| `.github/FUNDING.yml` | new | Turns on the repo-wide **Sponsor** button |
| `README.md` (footer) | replace "a star helps" with star + Discussions + Sponsor CTAs | It was the **only** CTA in 489 lines, asking for a $0 action at the highest-intent slot |
| `pyproject.toml` | "Multi-model AI trading bot" → honest toolkit description | Only one model is called per decision (issue #55); keeps every surface consistent with the README |
| `env.template` | drop the "Claude/GPT/Gemini/DeepSeek/Grok" ensemble implication | Same — one OpenRouter key for whichever single model you configure |

## Activation (manual, owner-side)
- **GitHub Sponsors**: enable at https://github.com/sponsors so the Sponsor button + the README Sponsor link render.
- **Discussions**: turn on in repo Settings so the README Discussions link is live (I can do this via `gh` if you want).
- **Homepage URL**: left unset — point it at a landing page once one exists.

CI-safe: `92 tests collected`, suite green in the 3.12 replica. Kept separate from the optimizer correctness fix (#57).