### PR TITLE
fix: NO-side positions stop out immediately (price-space inversion + missing v2 price fields)

### DIFF
--- a/src/clients/openrouter_client.py
+++ b/src/clients/openrouter_client.py
@@ -145,6 +145,12 @@ class OpenRouterClient(TradingLoggerMixin):
 
         # Aggregate cost tracking
         self.total_cost: float = 0.0
+        # Cost of the most recent request. The XAIClient shim reads this via
+        # getattr(client, "_last_request_cost", 0.0) to mirror spend into the
+        # tracker beast_mode_bot's cycle throttle checks; the attribute was
+        # never set, so that mirror recorded 0.0 forever. Declared here so it
+        # always exists.
+        self._last_request_cost: float = 0.0
         self.request_count: int = 0
 
         # Daily usage tracker (same pattern as XAIClient)
@@ -203,6 +209,10 @@ class OpenRouterClient(TradingLoggerMixin):
 
     def _update_daily_cost(self, cost: float) -> None:
         """Add *cost* to the daily tracker and check the limit."""
+        # Publish the last request's cost so the XAIClient shim can mirror it
+        # into the tracker beast_mode_bot's cycle throttle actually reads.
+        self._last_request_cost = cost
+
         self.daily_tracker.total_cost += cost
         self.daily_tracker.request_count += 1
         self._save_daily_tracker()

--- a/src/jobs/track.py
+++ b/src/jobs/track.py
@@ -34,9 +34,16 @@ async def should_exit_position(
     
     # 1. Market resolution (original logic)
     if market_status == 'closed':
-        # If market resolved, use the result to determine exit price
+        # If market resolved, use the result to determine exit price.
+        # Case-normalise both sides: Kalshi returns result as lowercase
+        # "yes"/"no" while Position.side is stored uppercase "YES"/"NO", so a
+        # raw == comparison is ALWAYS False and every resolved position settled
+        # at 0.0 — booking a total loss on winners too. (paper_trader.py already
+        # did result.lower() for the same field.)
         if market_result:
-            exit_price = 1.0 if market_result == position.side else 0.0
+            resolved_side = str(market_result).strip().lower()
+            held_side = str(position.side).strip().lower()
+            exit_price = 1.0 if resolved_side == held_side else 0.0
         else:
             # Fallback to current price if no result available
             exit_price = current_price
@@ -65,15 +72,12 @@ async def should_exit_position(
     
     # 3. Take-profit exit (enhanced logic for YES/NO)
     if position.take_profit_price:
-        take_profit_triggered = False
-        
-        if position.side == "YES":
-            # For YES positions, take profit when price rises above target
-            take_profit_triggered = current_price >= position.take_profit_price
-        else:
-            # For NO positions, take profit when price falls below target
-            take_profit_triggered = current_price <= position.take_profit_price
-            
+        # Own-side price convention (see src/utils/stop_loss_calculator.py):
+        # `current_price` above is already the held side's own price, and a
+        # position of either side gains when that price rises. The previous NO
+        # branch fired on a *fall*, i.e. it took profit while losing money.
+        take_profit_triggered = current_price >= position.take_profit_price
+
         if take_profit_triggered:
             return True, "take_profit", current_price
     
@@ -186,21 +190,59 @@ async def run_tracking(db_manager: Optional[DatabaseManager] = None):
                     logger.warning(f"Could not retrieve market data for {position.market_id}. Skipping.")
                     continue
 
-                # Get current prices
-                current_yes_price = market_data.get('yes_price', 0) / 100  # Convert cents to dollars
-                current_no_price = market_data.get('no_price', 0) / 100
+                # Get current prices. The legacy yes_price / no_price fields are
+                # not returned by Kalshi API v2 (only *_dollars), so reading them
+                # yielded 0.0 for every position and every exit decision below
+                # was made against a zero mark. Use the repo's normalizer and
+                # mark at mid-book, falling back to the last trade.
+                from src.utils.market_prices import get_market_prices
+                yes_bid, yes_ask, no_bid, no_ask = get_market_prices(market_data)
+                if yes_bid + yes_ask > 0:
+                    current_yes_price = (yes_bid + yes_ask) / 2
+                else:
+                    current_yes_price = float(market_data.get('last_price_dollars') or 0)
+                if no_bid + no_ask > 0:
+                    current_no_price = (no_bid + no_ask) / 2
+                else:
+                    current_no_price = (1.0 - current_yes_price) if current_yes_price > 0 else 0.0
+
+                # Last resort: the pre-v2 cent-denominated fields, for any
+                # payload that still carries them.
+                if current_yes_price <= 0 and market_data.get('yes_price'):
+                    current_yes_price = float(market_data['yes_price']) / 100
+                if current_no_price <= 0 and market_data.get('no_price'):
+                    current_no_price = float(market_data['no_price']) / 100
                 market_status = market_data.get('status', 'unknown')
                 market_result = market_data.get('result')  # Market resolution result
                 
-                # If position doesn't have exit strategy set, calculate defaults
-                if not position.stop_loss_price and not position.take_profit_price:
-                    logger.info(f"Setting up exit strategy for position {position.market_id}")
+                # Exit levels must bracket the entry price under the own-side
+                # convention (see src/utils/stop_loss_calculator.py): stop BELOW
+                # entry, target ABOVE it. Levels that fail that test are either
+                # missing or mis-anchored — e.g. rows written while positions
+                # were priced at a phantom $0.50 carry stop 0.535 / target 0.40
+                # against a real ~0.955 fill, and a target below the current
+                # mark fires a bogus "take_profit" on the very next pass.
+                # Re-anchor from the position's actual entry price.
+                levels_incoherent = (
+                    (position.stop_loss_price or 0) >= position.entry_price
+                    or (position.take_profit_price or 1.0) <= position.entry_price
+                )
+                if (not position.stop_loss_price and not position.take_profit_price) or levels_incoherent:
+                    if levels_incoherent:
+                        logger.warning(
+                            f"Re-anchoring incoherent exit levels for {position.market_id}: "
+                            f"entry={position.entry_price:.3f} stop={position.stop_loss_price} "
+                            f"target={position.take_profit_price}"
+                        )
+                    else:
+                        logger.info(f"Setting up exit strategy for position {position.market_id}")
+
                     exit_levels = await calculate_dynamic_exit_levels(position)
-                    
-                    # Update position with exit strategy (this would need a new DB method)
-                    # For now, we'll apply them dynamically
+
+                    # Applied in-memory for this pass; add_position persists the
+                    # levels for new positions.
                     position.stop_loss_price = exit_levels["stop_loss_price"]
-                    position.take_profit_price = exit_levels["take_profit_price"] 
+                    position.take_profit_price = exit_levels["take_profit_price"]
                     position.max_hold_hours = exit_levels["max_hold_hours"]
                     position.target_confidence_change = exit_levels["target_confidence_change"]
 

--- a/src/strategies/unified_trading_system.py
+++ b/src/strategies/unified_trading_system.py
@@ -22,6 +22,7 @@ Key innovations:
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass, asdict
@@ -478,6 +479,22 @@ class UnifiedAdvancedTradingSystem:
                         continue
                     
                     self.logger.info(f"✅ CASH RESERVES OK FOR ALLOCATION: {market_id}")
+
+                    # Re-entry cooldown: refuse to pile back into a market we
+                    # just closed out. add_position() only dedups while a
+                    # position is open, so without this a fast exit can be
+                    # re-entered every cycle indefinitely — costing an LLM
+                    # decision each time. Set REENTRY_COOLDOWN_MINUTES=0 to
+                    # disable.
+                    cooldown_minutes = int(os.getenv("REENTRY_COOLDOWN_MINUTES", "60"))
+                    if cooldown_minutes > 0 and await self.db_manager.was_recently_traded(
+                        market_id, intended_side, minutes=cooldown_minutes
+                    ):
+                        self.logger.info(
+                            f"⏳ RE-ENTRY COOLDOWN: {market_id} {intended_side} was closed "
+                            f"within the last {cooldown_minutes}m; skipping."
+                        )
+                        continue
                     
                     # Get current market data
                     market_data = await self.kalshi_client.get_market(market_id)
@@ -488,12 +505,34 @@ class UnifiedAdvancedTradingSystem:
                     # FIXED: Extract from nested 'market' object
                     market_info = market_data.get('market', {})
                     
-                    # Get price for the intended side (already determined above)
-                    if intended_side == "YES":
-                        price = market_info.get('yes_price', 50) / 100
-                    else:
-                        price = market_info.get('no_price', 50) / 100
-                    
+                    # Price the intended side off the real book.
+                    #
+                    # This previously read market_info.get('no_price', 50) / 100.
+                    # Kalshi API v2 does not return the legacy yes_price /
+                    # no_price fields at all (the market object carries only
+                    # *_dollars fields), so `.get(..., 50)` silently fell through
+                    # to the literal default and every position was created at a
+                    # phantom $0.50. That both mis-sized quantity (~2x too many
+                    # contracts on a ~$0.95 market) and anchored the stop-loss /
+                    # take-profit levels below to 0.50 while the real fill was
+                    # ~0.95 — so every position stopped out on its first
+                    # tracking pass.
+                    #
+                    # Buy at the ask (what a taker actually pays) via the repo's
+                    # existing normalizer, and skip the allocation if the book
+                    # gives us nothing usable rather than inventing a price.
+                    from src.utils.market_prices import get_market_prices
+                    yes_bid, yes_ask, no_bid, no_ask = get_market_prices(market_info)
+                    price = yes_ask if intended_side == "YES" else no_ask
+
+                    if not price or price <= 0.0 or price >= 1.0:
+                        self.logger.warning(
+                            f"No usable {intended_side} ask for {market_id} "
+                            f"(yes_ask={yes_ask}, no_ask={no_ask}); skipping allocation "
+                            f"rather than assuming a price."
+                        )
+                        continue
+
                     # Calculate quantity
                     quantity = max(1, int(position_value / price))
                     

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -870,6 +870,37 @@ class DatabaseManager(TradingLoggerMixin):
             count = (await cursor.fetchone())[0]
             return count > 0
 
+    async def was_recently_traded(
+        self, market_id: str, side: str = None, minutes: int = 60
+    ) -> bool:
+        """Check whether this market was closed out within the last *minutes*.
+
+        Re-entry cooldown. ``add_position`` already refuses a duplicate while a
+        position is OPEN, but the moment one closes the market becomes eligible
+        again — so a position that exits quickly can be re-entered on the very
+        next cycle, indefinitely, burning an LLM decision each time.
+
+        Args:
+            market_id: Market to check.
+            side: Optional side filter ("YES"/"NO"); any side when omitted.
+            minutes: Cooldown window in minutes.
+
+        Returns:
+            True if a trade in this market closed inside the window.
+        """
+        cutoff_str = (datetime.now() - timedelta(minutes=minutes)).isoformat()
+
+        query = "SELECT COUNT(*) FROM trade_logs WHERE market_id = ? AND exit_timestamp > ?"
+        params = [market_id, cutoff_str]
+        if side:
+            query += " AND side = ?"
+            params.append(side)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(query, tuple(params))
+            count = (await cursor.fetchone())[0]
+            return count > 0
+
     async def get_daily_ai_cost(self, date: str = None) -> float:
         """Get total AI cost for a specific date (defaults to today)."""
         if date is None:

--- a/src/utils/stop_loss_calculator.py
+++ b/src/utils/stop_loss_calculator.py
@@ -6,9 +6,27 @@ Provides consistent stop-loss calculation across all trading strategies.
 
 Key Features:
 - 5-10% stop-loss based on entry price and confidence
-- Adaptive stop-loss based on market volatility  
+- Adaptive stop-loss based on market volatility
 - Take-profit targets to lock in gains
 - Time-based exit strategies
+
+PRICE CONVENTION — read before editing
+--------------------------------------
+Every price here is the **price of the contract actually held** ("own-side"
+price), never the YES price of the market. On Kalshi you buy a contract: a NO
+position is a NO contract bought at the NO ask, and it is worth $1 if NO
+resolves. So a position of EITHER side loses value when its own contract price
+falls, and gains when it rises. Stop-loss is therefore always BELOW entry and
+triggers on a fall; take-profit is always ABOVE entry and triggers on a rise.
+There is no YES/NO asymmetry, and the `side` arguments are retained only for
+call-site compatibility and logging.
+
+This replaces an earlier YES-space convention (for NO: stop above entry,
+trigger on a rise). That convention was self-consistent but every caller fed it
+own-side prices — `Position.entry_price` is the fill price of the side traded
+and `track.py` passes `current_no_price` for NO positions — so a NO position at
+0.95 was compared against a stop of 0.95*1.07 and stopped out on its first
+tracking pass, every time.
 """
 
 from typing import Dict, Optional
@@ -87,16 +105,12 @@ class StopLossCalculator:
         else:
             take_profit_pct = cls.MIN_TAKE_PROFIT_PCT  # 15% for low confidence
             
-        # Calculate actual price levels based on side
-        if side.upper() == "YES":
-            # For YES positions, stop-loss is below entry, take-profit is above
-            stop_loss_price = entry_price * (1 - adjusted_stop_loss_pct)
-            take_profit_price = entry_price * (1 + take_profit_pct)
-        else:
-            # For NO positions, stop-loss is above entry, take-profit is below  
-            stop_loss_price = entry_price * (1 + adjusted_stop_loss_pct)
-            take_profit_price = entry_price * (1 - take_profit_pct)
-            
+        # Own-side price convention (see module docstring): a position of either
+        # side loses when its own contract price falls. Stop below, target above.
+        stop_loss_price = entry_price * (1 - adjusted_stop_loss_pct)
+        take_profit_price = entry_price * (1 + take_profit_pct)
+
+
         # Ensure prices are within valid bounds (1¢ to 99¢)
         stop_loss_price = max(0.01, min(0.99, stop_loss_price))
         take_profit_price = max(0.01, min(0.99, take_profit_price))
@@ -133,11 +147,9 @@ class StopLossCalculator:
         Returns:
             Stop-loss price
         """
-        if side.upper() == "YES":
-            stop_loss_price = entry_price * (1 - stop_loss_pct)
-        else:
-            stop_loss_price = entry_price * (1 + stop_loss_pct)
-            
+        # Own-side price convention (see module docstring): stop always below entry.
+        stop_loss_price = entry_price * (1 - stop_loss_pct)
+
         return max(0.01, min(0.99, round(stop_loss_price, 2)))
     
     @classmethod
@@ -160,12 +172,9 @@ class StopLossCalculator:
         Returns:
             True if stop-loss should be triggered
         """
-        if position_side.upper() == "YES":
-            # For YES positions, trigger if price drops below stop-loss
-            return current_price <= stop_loss_price
-        else:
-            # For NO positions, trigger if price rises above stop-loss
-            return current_price >= stop_loss_price
+        # Own-side price convention (see module docstring): both sides lose when
+        # the held contract's own price falls, so the test is side-independent.
+        return current_price <= stop_loss_price
     
     @classmethod
     def calculate_pnl_at_stop_loss(
@@ -181,11 +190,13 @@ class StopLossCalculator:
         Returns:
             Expected P&L (negative for loss)
         """
-        if side.upper() == "YES":
-            pnl_per_share = stop_loss_price - entry_price
-        else:
-            pnl_per_share = entry_price - stop_loss_price
-            
+        # Own-side price convention (see module docstring): P&L per contract is
+        # exit minus entry for either side, so a stop below entry yields a loss.
+        # The previous NO branch returned entry - stop, which reported a POSITIVE
+        # number for a stopped-out NO position (visible in exit reasons logged as
+        # "stop_loss_triggered_pnl_12.60" on trades that actually lost money).
+        pnl_per_share = stop_loss_price - entry_price
+
         return pnl_per_share * quantity
 
 

--- a/tests/test_no_side_exit_regressions.py
+++ b/tests/test_no_side_exit_regressions.py
@@ -1,0 +1,225 @@
+"""Regression tests for the NO-side exit-logic churn loop.
+
+Four independent defects combined to make every NO position stop out within
+~1 minute of entry: 160 trades, 0 wins, across only 4 markets (two re-entered
+71 times each). Each is pinned here because all four were silent — the suite
+was green throughout.
+
+1. `unified_trading_system` priced positions from the legacy `no_price` field,
+   which Kalshi API v2 does not return, so it defaulted to a phantom 50c.
+2. Exit levels were therefore anchored to 0.50 while the real fill was ~0.95.
+3. `StopLossCalculator` worked in YES-price space while every caller fed it
+   own-side prices, so a NO stop sat ABOVE entry and triggered on any rise.
+4. Resolution compared Kalshi's lowercase `result` against an uppercase
+   `Position.side`, so a settled winner booked as a total loss.
+"""
+import os
+from datetime import datetime
+
+import pytest
+
+from src.jobs.track import should_exit_position
+from src.utils.database import Position
+from src.utils.stop_loss_calculator import StopLossCalculator
+
+
+def _no_position(entry_price=0.955, stop_loss_price=None, take_profit_price=None):
+    """A NO position priced like the near-certainties the strategy actually picks."""
+    return Position(
+        market_id="KXGREENLAND-29-27",
+        side="NO",
+        entry_price=entry_price,
+        quantity=60,
+        timestamp=datetime.now(),
+        rationale="regression fixture",
+        confidence=0.82,
+        live=False,
+        status="open",
+        stop_loss_price=stop_loss_price,
+        take_profit_price=take_profit_price,
+    )
+
+
+class TestOwnSidePriceConvention:
+    """Defect 3: stop below entry / target above entry, for BOTH sides."""
+
+    @pytest.mark.parametrize("side", ["YES", "NO"])
+    def test_stop_below_entry_and_target_above(self, side):
+        levels = StopLossCalculator.calculate_stop_loss_levels(
+            entry_price=0.95, side=side, confidence=0.82
+        )
+        assert levels["stop_loss_price"] < 0.95, (
+            f"{side} stop must sit BELOW entry — a stop above entry triggers on a "
+            f"price rise, i.e. it exits a winning position"
+        )
+        assert levels["take_profit_price"] > 0.95, f"{side} target must sit ABOVE entry"
+
+    @pytest.mark.parametrize("side", ["YES", "NO"])
+    def test_simple_stop_below_entry(self, side):
+        stop = StopLossCalculator.calculate_simple_stop_loss(
+            entry_price=0.95, side=side, stop_loss_pct=0.10
+        )
+        assert stop < 0.95
+
+    def test_no_stop_does_not_trigger_on_a_tiny_adverse_move(self):
+        """The exact production case: NO bought at 0.955, book mid 0.9535."""
+        assert (
+            StopLossCalculator.is_stop_loss_triggered(
+                position_side="NO",
+                entry_price=0.955,
+                current_price=0.9535,
+                stop_loss_price=0.888,
+            )
+            is False
+        )
+
+    def test_no_stop_triggers_on_a_real_drop(self):
+        assert (
+            StopLossCalculator.is_stop_loss_triggered(
+                position_side="NO",
+                entry_price=0.955,
+                current_price=0.85,
+                stop_loss_price=0.888,
+            )
+            is True
+        )
+
+    def test_stopped_out_no_position_reports_a_loss(self):
+        """Exit reasons logged 'stop_loss_triggered_pnl_12.60' on losing trades."""
+        pnl = StopLossCalculator.calculate_pnl_at_stop_loss(
+            entry_price=0.955, stop_loss_price=0.888, quantity=60, side="NO"
+        )
+        assert pnl < 0, "a stop-out is a loss; the NO branch used to report it positive"
+
+
+class TestNoPositionSurvivesEntry:
+    """Defects 2+3 together: the symptom the user actually saw."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_no_position_is_not_exited_immediately(self):
+        """Entry at the ask, mark at the mid — must NOT exit on the first pass."""
+        position = _no_position(entry_price=0.955)
+        levels = StopLossCalculator.calculate_stop_loss_levels(
+            entry_price=position.entry_price, side="NO", confidence=0.82
+        )
+        position.stop_loss_price = levels["stop_loss_price"]
+        position.take_profit_price = levels["take_profit_price"]
+
+        should_exit, reason, _ = await should_exit_position(
+            position=position,
+            current_yes_price=0.0465,
+            current_no_price=0.9535,
+            market_status="active",
+            market_result=None,
+        )
+        assert should_exit is False, f"exited immediately via {reason!r}"
+
+    @pytest.mark.asyncio
+    async def test_phantom_50c_levels_are_detected_as_incoherent(self):
+        """Defect 2: 0.50-anchored levels on a 0.955 fill.
+
+        Fixing the stop direction alone is not enough — a target of 0.40 sits
+        BELOW the 0.9535 mark, so it fires a bogus take-profit on the next pass.
+        `run_tracking` detects levels that fail to bracket the entry price and
+        re-anchors them; this pins the detection rule those legacy rows hit.
+        """
+        position = _no_position(
+            entry_price=0.955, stop_loss_price=0.535, take_profit_price=0.40
+        )
+
+        levels_incoherent = (
+            (position.stop_loss_price or 0) >= position.entry_price
+            or (position.take_profit_price or 1.0) <= position.entry_price
+        )
+        assert levels_incoherent is True, "0.535/0.40 against a 0.955 entry must be flagged"
+
+        # Confirm the danger is real if they were left in place: the stale target
+        # is below the mark, so an exit WOULD fire without re-anchoring.
+        should_exit, reason, _ = await should_exit_position(
+            position=position,
+            current_yes_price=0.0465,
+            current_no_price=0.9535,
+            market_status="active",
+            market_result=None,
+        )
+        assert should_exit is True and reason == "take_profit"
+
+        # After re-anchoring from the real entry price, the position survives.
+        levels = StopLossCalculator.calculate_stop_loss_levels(
+            entry_price=position.entry_price, side="NO", confidence=0.82
+        )
+        position.stop_loss_price = levels["stop_loss_price"]
+        position.take_profit_price = levels["take_profit_price"]
+
+        should_exit_after, reason_after, _ = await should_exit_position(
+            position=position,
+            current_yes_price=0.0465,
+            current_no_price=0.9535,
+            market_status="active",
+            market_result=None,
+        )
+        assert should_exit_after is False, f"still exits via {reason_after!r} after re-anchoring"
+
+
+class TestResolutionCaseNormalisation:
+    """Defect 4: latent until positions are held long enough to settle."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "side,result,expected",
+        [
+            ("NO", "no", 1.0),
+            ("NO", "yes", 0.0),
+            ("YES", "yes", 1.0),
+            ("YES", "no", 0.0),
+            ("NO", "NO", 1.0),
+            ("YES", " Yes ", 1.0),
+        ],
+    )
+    async def test_settlement_price_matches_case_insensitively(self, side, result, expected):
+        position = _no_position()
+        position.side = side
+
+        should_exit, reason, exit_price = await should_exit_position(
+            position=position,
+            current_yes_price=0.5,
+            current_no_price=0.5,
+            market_status="closed",
+            market_result=result,
+        )
+        assert should_exit is True
+        assert reason == "market_resolution"
+        assert exit_price == expected, (
+            f"side={side!r} result={result!r} settled at {exit_price} not {expected}; "
+            f"a raw == comparison books every winner as a total loss"
+        )
+
+
+class TestCostTrackerMirroring:
+    """The daily cycle throttle read a tracker that never accrued cost."""
+
+    def test_openrouter_publishes_last_request_cost(self):
+        from src.clients.openrouter_client import OpenRouterClient
+
+        assert hasattr(OpenRouterClient, "_update_daily_cost")
+
+        client = OpenRouterClient.__new__(OpenRouterClient)
+        client._last_request_cost = 0.0
+
+        class _Tracker:
+            total_cost = 0.0
+            request_count = 0
+            daily_limit = 2.0
+            is_exhausted = False
+            last_exhausted_time = None
+
+        client.daily_tracker = _Tracker()
+        client._save_daily_tracker = lambda: None
+
+        OpenRouterClient._update_daily_cost(client, 0.0042)
+
+        assert client._last_request_cost == pytest.approx(0.0042), (
+            "XAIClient mirrors this attribute into the tracker beast_mode_bot "
+            "reads; without it the bot-level daily throttle never fires"
+        )
+        assert client.daily_tracker.total_cost == pytest.approx(0.0042)


### PR DESCRIPTION
## Summary

Four defects combine so that **no NO position can survive its first tracking pass**. I hit this running the default `cli.py run --paper` path against production prices for two days:

- **160 trades, 0 wins**, across only **4 markets** (two re-entered 71 times each)
- Average hold **1.11 minutes**; shortest **0.6 seconds**
- Every trade bought at the ask and stopped out at the bid, losing the spread each time

0 wins is not variance — it was arithmetically impossible to win, because winning requires reaching settlement and nothing survived a minute. Each defect is independent, and all four were silent (the suite was green throughout).

## 1. Legacy price fields no longer exist in Kalshi API v2

`unified_trading_system.py` priced positions with:

```python
price = market_info.get('no_price', 50) / 100
```

The v2 market object carries only `*_dollars` fields — `no_price` is absent, not null — so `.get(..., 50)` returned the literal default on **every** call. Every position was created at a phantom **$0.50**, which:

- mis-sized quantity ~2x (60 contracts where ~31 was intended on a ~$0.95 market), and
- anchored stop-loss/take-profit to 0.50 while the real fill was ~0.95

`track.py` had the same bug reading `yes_price`/`no_price` for the current mark, producing `0.0` and making every exit decision against a zero price.

Both now use the repo's existing `get_market_prices()` normalizer. The allocation path **skips** a market rather than inventing a price; the tracking path keeps a cent-denominated fallback so older payloads (and the existing tests' mocks) still work.

## 2. `StopLossCalculator` works in YES-price space, but callers pass own-side prices

For NO it placed the stop **above** entry and triggered on a price **rise**:

```python
stop_loss_price = entry_price * (1 + adjusted_stop_loss_pct)   # NO
return current_price >= stop_loss_price                        # NO
```

That is self-consistent *if* `entry_price` and `current_price` are both the YES price. But they aren't: `Position.entry_price` is the fill price of the side traded, and `track.py:33` passes `current_no_price` for NO positions. So a NO position at 0.955 was tested against `current >= 0.535` and stopped out immediately.

On Kalshi you *buy a contract*, and a contract of either side loses value when its own price falls. Normalised to that convention: **stop below entry, target above, side-independent**. The YES/NO branching was the bug, not a feature. Documented at module level so it can't silently regress.

The same inversion existed in `track.py`'s take-profit branch, which for NO fired on a *fall* — taking profit while losing money.

## 3. `calculate_pnl_at_stop_loss` returns the wrong sign for NO

It computed `entry - stop`, reporting a **positive** number for a stopped-out NO position. Visible in logged exit reasons: `stop_loss_triggered_pnl_12.60` on a trade that lost $1.64.

## 4. Settlement compares mismatched case (latent)

Kalshi returns `result` as lowercase `"yes"`/`"no"`; `Position.side` is stored uppercase. So:

```python
exit_price = 1.0 if market_result == position.side else 0.0
```

is **always** `False` → every resolved position settles at `0.0`, booking a total loss on winners too. This never fired in my run only because nothing was held long enough to settle — it would bite the moment 1-3 are fixed. Note `paper_trader.py` already lower-cases this same field, which is what tipped me off.

## Also included

- **Level re-anchoring** in `track.py` for positions whose stop/target don't bracket entry. Fixing the stop direction alone isn't enough: a stale target *below* the current mark fires a bogus `take_profit` instead. A test caught this.
- **Re-entry cooldown** (`REENTRY_COOLDOWN_MINUTES`, default 60) via `DatabaseManager.was_recently_traded()`. `add_position` only dedups while a position is *open*, so a fast exit could be re-entered every cycle forever — which is why 2 markets absorbed 142 of the 160 trades, at one LLM decision each.
- **`OpenRouterClient._last_request_cost`** is now set. The `XAIClient` shim reads it via `getattr(client, "_last_request_cost", 0.0)` to mirror spend into the tracker `beast_mode_bot._check_daily_ai_limits()` checks — but nothing ever set it, so that tracker stayed at `$0.00` and the bot never paused on its daily limit. It kept spinning after the cost cap was reached (433 requests logged on a day pinned at the limit) because only `OpenRouterClient`'s own gate stopped the spend.

## Tests

**101 pass, was 85.** 16 new regression tests in `tests/test_no_side_exit_regressions.py` pin all four defects, including the exact production case (NO bought at 0.955, book mid 0.9535, must not exit).

## Reviewer notes

- The `stop_loss_calculator.py` change alters **shared** semantics. Existing tests only covered `side="YES"` with a stop below entry — which is exactly the normalised convention — so YES behaviour is unchanged.
- `decide.py:167` still passes `market.yes_price` with `side=decision.side`. It's on the exception-fallback path and that block is YES-specific, so I left it alone, but it's the same class of inconsistency and worth a follow-up.
- Verified against the live API after deploying: real NO ask `0.954` (was `0.50`), stop `0.91` / target `0.99` correctly bracketing entry, and no immediate stop-out at the `0.9535` mid.
- Happy to split this into four PRs if you'd prefer to review them separately — they're independent, though 1 and 2 have to land together for either to help.